### PR TITLE
tools/pewrap: --post-process-for-ukify: Set PE MajorImageVersion to 1

### DIFF
--- a/tools/pewrap/src/cli.rs
+++ b/tools/pewrap/src/cli.rs
@@ -97,6 +97,9 @@ pub struct Args {
     /// This option instructs pewrap to relayout the image by setting SizeOfHeaders
     /// to as large as possible, maximizing the number of sections that can be added by
     /// systemd-ukify later on.
+    ///
+    /// Additionally it sets the PE major version to 1, which is also required by ukify,
+    /// otherwise it will never indicate support for LoadFile2.
     #[arg(long)]
     pub post_process_for_ukify: bool,
 }

--- a/tools/pewrap/src/main.rs
+++ b/tools/pewrap/src/main.rs
@@ -168,6 +168,13 @@ fn main() {
         );
     }
 
+    // If we are called with --post-process-for-ukify, set PE major version to 1 for LoadFile2
+    // We set this above only if the Linux kernel supports it, but ukify never sets it itself,
+    // so we need to set it here unconditionally.
+    if args.post_process_for_ukify {
+        bld.nt_hdrs.optional_header.major_image_version = 1;
+    }
+
     // Calculate section offsets
     if let Err(e) = bld.fixup_offsets(args.post_process_for_ukify) {
         eprintln!("{}: {}", args.output.display(), e);


### PR DESCRIPTION
This is necessary for ukify generated stubble images to indicate LoadFile2 support, otherwise they never will.

Ideally this is only set when the kernel supports LoadFile2, and we error out otherwise, but ukify does not have this ability.