### PR TITLE
lace-platform tech debt cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,6 +269,7 @@ dependencies = [
  "lace-util",
  "lace-util-derive",
  "linked_list_allocator",
+ "log",
  "spin",
  "uefi",
  "uefi-raw",
@@ -282,6 +283,7 @@ dependencies = [
  "lace-platform",
  "lace-stubble",
  "lace-util",
+ "log",
 ]
 
 [[package]]
@@ -290,6 +292,7 @@ version = "0.1.0"
 dependencies = [
  "lace-platform",
  "lace-util",
+ "log",
  "uefi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ ext4-view = { version = "0.9", default-features = false }
 fdt = { version = "0.1.5", default-features = false }
 libc = "0.2"
 linked_list_allocator = { version = "0.10.5" }
+log = { version = "0.4", default-features = false }
 proc-macro2 = "1.0"
 quote = "1.0"
 regex = "1.12.3"

--- a/lace-platform/Cargo.toml
+++ b/lace-platform/Cargo.toml
@@ -13,7 +13,7 @@ linked_list_allocator = { workspace = true, optional = true }
 log.workspace = true
 spin.workspace = true
 zerocopy = { workspace = true, features = ["derive"] }
-uefi = { workspace = true, features = ["global_allocator", "panic_handler"], optional = true }
+uefi = { workspace = true, features = ["global_allocator"], optional = true }
 uefi-raw = { workspace = true, optional = true }
 
 [features]

--- a/lace-platform/Cargo.toml
+++ b/lace-platform/Cargo.toml
@@ -10,6 +10,7 @@ ext4-view = { workspace = true, optional = true }
 lace-util = { path = "../lace-util", default-features = false }
 lace-util-derive = { path = "../lace-util-derive" }
 linked_list_allocator = { workspace = true, optional = true }
+log.workspace = true
 spin.workspace = true
 zerocopy = { workspace = true, features = ["derive"] }
 uefi = { workspace = true, features = ["global_allocator", "panic_handler"], optional = true }

--- a/lace-platform/src/bios/console.rs
+++ b/lace-platform/src/bios/console.rs
@@ -48,6 +48,16 @@ impl Output for OutputImpl {
     fn set_position(&mut self, _x: usize, _y: usize) -> Result<(), crate::Error> {
         Ok(())
     }
+
+    fn clear_screen(&mut self) -> Result<(), crate::Error> {
+        let mut regs = BiosRegisters::new();
+        // INT 10h AH=00h AL=03h: set video mode 80x25 text (clears the screen).
+        regs.eax = 0x0003;
+        unsafe {
+            bios_call(0x10, &mut regs);
+        }
+        Ok(())
+    }
 }
 
 /// BIOS console input

--- a/lace-platform/src/bios/console.rs
+++ b/lace-platform/src/bios/console.rs
@@ -1,34 +1,24 @@
 // SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
 // Copyright (C) 2025, Canonical Ltd.
 // Authors: Mate Kukri <mate.kukri@canonical.com>
-
-//! BIOS Services for Printing
+//! BIOS console
 
 use super::int::{BiosRegisters, bios_call};
-use core::fmt::Write;
-use spin::mutex::Mutex;
+use crate::console::{Input, InputEvent, Output};
 
-/// Platform specific text output
-pub fn print_impl(args: core::fmt::Arguments<'_>) {
-    let mut output = OUTPUT.lock();
-    write!(output, "{}", args).unwrap();
-}
-
-/// Platform specific text output with newline
-pub fn println_impl(args: core::fmt::Arguments<'_>) {
-    let mut output = OUTPUT.lock();
-    writeln!(output, "{}", args).unwrap();
-}
-
-/// Global Output instance for BIOS text output
-pub static OUTPUT: Mutex<Output> = Mutex::new(Output { _private: () });
-
-/// Output struct implementing core::fmt::Write for BIOS text output
-pub struct Output {
+/// BIOS console output
+pub struct OutputImpl {
     _private: (),
 }
 
-impl core::fmt::Write for Output {
+impl OutputImpl {
+    #[allow(clippy::new_without_default)]
+    pub const fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+impl core::fmt::Write for OutputImpl {
     fn write_char(&mut self, c: char) -> core::fmt::Result {
         if c == '\n' {
             self.write_char('\r')?;
@@ -50,37 +40,39 @@ impl core::fmt::Write for Output {
     }
 }
 
-/// Keyboard event structure containing character and scancode
-#[derive(Debug, Clone, Copy)]
-pub struct KeyEvent {
-    pub char: char,
-    pub scancode: u8,
+impl Output for OutputImpl {
+    fn get_position(&mut self) -> Result<(usize, usize), crate::Error> {
+        Ok((0, 0))
+    }
+
+    fn set_position(&mut self, _x: usize, _y: usize) -> Result<(), crate::Error> {
+        Ok(())
+    }
 }
 
-/// Global Input instance for BIOS keyboard input
-pub static INPUT: Mutex<Input> = Mutex::new(Input { _private: () });
-
-/// Input struct for BIOS keyboard input
-pub struct Input {
+/// BIOS console input
+pub struct InputImpl {
     _private: (),
 }
 
-impl Input {
+impl InputImpl {
+    #[allow(clippy::new_without_default)]
+    pub const fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+impl Input for InputImpl {
     /// Read a single keystroke from the keyboard (blocking)
-    pub fn read_key(&mut self) -> KeyEvent {
+    fn wait_input(&mut self) -> Result<InputEvent, crate::Error> {
         let mut regs = BiosRegisters::new();
         regs.eax = 0x0000; // AH = 0x00 (Read Keystroke)
         unsafe {
             bios_call(0x16, &mut regs);
         }
-        KeyEvent {
+        Ok(InputEvent {
             char: (regs.eax & 0xFF) as u8 as char,
             scancode: ((regs.eax >> 8) & 0xFF) as u8,
-        }
+        })
     }
-}
-
-/// Read a key from the keyboard
-pub fn read_key() -> Result<KeyEvent, super::Error> {
-    Ok(INPUT.lock().read_key())
 }

--- a/lace-platform/src/bios/defs.s
+++ b/lace-platform/src/bios/defs.s
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-only
-# Assembly definitions
+# Assembly definitions
 
 # Segment descriptors
 .equ SEG_CODE64, 0x08

--- a/lace-platform/src/bios/fs.rs
+++ b/lace-platform/src/bios/fs.rs
@@ -221,7 +221,7 @@ fn probe_disk(drive: u8) -> Option<Box<dyn BlockDevice>> {
         return None;
     }
     let params = int13h_get_parameters(drive).ok()?;
-    crate::debugln!("[BIOS] Discovered disk {:02X}", drive);
+    log::debug!("[BIOS] Discovered disk {:02X}", drive);
     Some(Box::new(BiosBlockDevice {
         drive,
         sector_size: params.bytes_per_sector as u32,
@@ -249,7 +249,7 @@ pub fn discover_boot_storage() -> DiscoveredStorage {
     // identity-mapped in the page tables, and valid for the lifetime of the
     // bootloader.
     let boot_drive: u8 = unsafe { *(0x7B00 as *const u8) };
-    crate::debugln!("[BIOS] Boot drive: {:02X}", boot_drive);
+    log::debug!("[BIOS] Boot drive: {:02X}", boot_drive);
 
     let mut result = DiscoveredStorage::new();
     result.disks = probe_disk(boot_drive).into_iter().collect();

--- a/lace-platform/src/bios/fs.rs
+++ b/lace-platform/src/bios/fs.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
 // Copyright (C) 2026, Canonical Ltd.
-
 //! BIOS block device, disk I/O, and storage discovery.
 
 use crate::bios;

--- a/lace-platform/src/bios/hwid.rs
+++ b/lace-platform/src/bios/hwid.rs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+// Copyright (C) 2025, Canonical Ltd.
+// Authors: Mate Kukri <mate.kukri@canonical.com>
+//! BIOS hardware identification
+
+use lace_util::fdt::Fdt;
+use lace_util::smbios::{Smbios3EntryPoint, SmbiosEntryPoint};
+
+/// Finds the EDID data.
+pub fn find_edid() -> Option<impl core::ops::Deref<Target = [u8]>> {
+    // TODO: Implement EDID finding via VBE (INT 10h AX=4F15h)
+    None::<&[u8]>
+}
+
+/// Finds SMBIOS tables by scanning the legacy memory range 0xF0000-0xFFFFF.
+pub fn find_smbios_tables() -> Option<(&'static [u8], &'static [u8])> {
+    let start = 0xF0000;
+    let end = 0xFFFFF;
+    let step = 16;
+
+    for addr in (start..=end).step_by(step) {
+        let ptr = addr as *const u8;
+        unsafe {
+            // Check for _SM3_ (SMBIOS 3.0)
+            if *ptr == b'_'
+                && *ptr.add(1) == b'S'
+                && *ptr.add(2) == b'M'
+                && *ptr.add(3) == b'3'
+                && *ptr.add(4) == b'_'
+            {
+                let entry = &*(ptr as *const Smbios3EntryPoint);
+                // TODO: Verify checksum
+                return Some((
+                    core::slice::from_raw_parts(ptr, core::mem::size_of::<Smbios3EntryPoint>()),
+                    core::slice::from_raw_parts(
+                        entry.table_address as *const u8,
+                        entry.table_maximum_size as usize,
+                    ),
+                ));
+            }
+            // Check for _SM_ (SMBIOS 2.1)
+            if *ptr == b'_' && *ptr.add(1) == b'S' && *ptr.add(2) == b'M' && *ptr.add(3) == b'_' {
+                let entry = &*(ptr as *const SmbiosEntryPoint);
+                // TODO: Verify checksum
+                return Some((
+                    core::slice::from_raw_parts(ptr, core::mem::size_of::<SmbiosEntryPoint>()),
+                    core::slice::from_raw_parts(
+                        entry.table_address as *const u8,
+                        entry.table_length as usize,
+                    ),
+                ));
+            }
+        }
+    }
+    None
+}
+
+/// Finds an installed DTB in the system.
+/// # Safety
+/// This is not implemented for now.
+pub unsafe fn find_dtb() -> Option<Fdt<'static>> {
+    todo!()
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DtbReceipt;
+
+/// Installs a DTB in the system.
+/// # Safety
+/// This is not implemented for now.
+pub unsafe fn install_dtb(_dtb: &[u8]) -> Result<DtbReceipt, super::Error> {
+    todo!()
+}

--- a/lace-platform/src/bios/int_trampoline.s
+++ b/lace-platform/src/bios/int_trampoline.s
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
-# BIOS Interrupt Trampoline Assembly
+# BIOS Interrupt Trampoline Assembly
 # This code switches the CPU from Long Mode to Real Mode,
 # performs a BIOS interrupt call, and then switches back to Long Mode.
 
@@ -22,7 +22,7 @@ bios_call_asm:
     push %r14
     push %r15
 
-    # Save RSP
+    # Save RSP
     mov %rsp, save_rsp
 
 
@@ -37,7 +37,7 @@ bios_call_asm:
 
 .code32
 .mode32:
-    # Load 32-bit Data Segments
+    # Load 32-bit Data Segments
     mov $SEG_DATA32, %ax
     mov %ax, %ds
     mov %ax, %es
@@ -50,7 +50,7 @@ bios_call_asm:
     and $0x7FFFFFFF, %eax
     mov %eax, %cr0
 
-    # Disable Long Mode in EFER
+    # Disable Long Mode in EFER
     mov $0xC0000080, %ecx
     rdmsr
     and $0xFFFFFEFF, %eax
@@ -61,7 +61,7 @@ bios_call_asm:
 
 .code16
 .mode16:
-    # Load 16-bit Data Segments
+    # Load 16-bit Data Segments
     mov $SEG_DATA16, %ax
     mov %ax, %ds
     mov %ax, %es
@@ -87,7 +87,7 @@ bios_call_asm:
     mov %ax, %fs
     mov %ax, %gs
 
-    # Setup Real Mode stack
+    # Setup Real Mode stack
     mov $rm_stack_top - 0x10000, %sp
 
     # Load Real Mode IDT (IVT at 0x0000)
@@ -111,7 +111,7 @@ bios_call_asm:
     pushl %ss:24(%bp)
     popl %ebp
 
-    # Enable interrupts
+    # Enable interrupts
     sti
 
     # Call BIOS Interrupt (with patched int number)
@@ -144,7 +144,7 @@ int_instruction:
     popl %eax
     mov %eax, %ss:24(%bp)
 
-    # Enable Protected Mode in CR0
+    # Enable Protected Mode in CR0
     mov %cr0, %eax
     or $1, %eax
     mov %eax, %cr0
@@ -155,7 +155,7 @@ int_instruction:
 .code32
 .pmode32:
 
-    # Reload 32-bit Data Segments
+    # Reload 32-bit Data Segments
     mov $SEG_DATA32, %ax
     mov %ax, %ds
     mov %ax, %es
@@ -169,7 +169,7 @@ int_instruction:
     or $0x100, %eax
     wrmsr
 
-    # Enable paging in CR0
+    # Enable paging in CR0
     mov %cr0, %eax
     or $0x80000000, %eax
     mov %eax, %cr0
@@ -180,7 +180,7 @@ int_instruction:
 .code64
 .long_mode:
 
-    # Reload 64-bit Data Segments
+    # Reload 64-bit Data Segments
     mov $SEG_DATA64, %ax
     mov %ax, %ds
     mov %ax, %es
@@ -188,10 +188,10 @@ int_instruction:
     mov %ax, %fs
     mov %ax, %gs
 
-    # Restore IDTR
+    # Restore IDTR
     lidt idtr
 
-    # Restore RSP
+    # Restore RSP
     mov save_rsp, %rsp
 
     pop %r15
@@ -222,7 +222,7 @@ rm_idtr:
 
 // .section .bss16
 
-# Real mode stack
+# Real mode stack
 .align 16
 rm_stack:
     .space 4096

--- a/lace-platform/src/bios/linux.rs
+++ b/lace-platform/src/bios/linux.rs
@@ -100,10 +100,10 @@ pub fn boot_linux(
         params.hdr.ramdisk_image = initrd_addr;
         params.hdr.ramdisk_size = initrd_data.len() as u32;
 
-        crate::println!("Kernel Entry: 0x{:08X}", kernel_entry);
-        crate::println!("Initrd Addr:  0x{:08X}", initrd_addr);
-        crate::println!("Initrd Size:  0x{:08X}", initrd_data.len());
-        crate::println!("Init Size:    0x{:08X}", init_size);
+        log::debug!("Kernel Entry: 0x{:08X}", kernel_entry);
+        log::debug!("Initrd Addr:  0x{:08X}", initrd_addr);
+        log::debug!("Initrd Size:  0x{:08X}", initrd_data.len());
+        log::debug!("Init Size:    0x{:08X}", init_size);
 
         let kernel_start = kernel_entry as u32;
         let kernel_end = kernel_start + init_size as u32;
@@ -111,15 +111,12 @@ pub fn boot_linux(
         let initrd_end = initrd_start + initrd_data.len() as u32;
 
         if kernel_start < initrd_end && initrd_start < kernel_end {
-            crate::println!("WARNING: Initrd overlaps with kernel initialization memory!");
+            log::warn!("Initrd overlaps with kernel initialization memory");
         }
 
         let max_addr = header.initrd_addr_max;
         if initrd_addr > max_addr {
-            crate::println!(
-                "WARNING: Initrd above initrd_addr_max (0x{:08X})!",
-                max_addr
-            );
+            log::warn!("Initrd placed above the kernel's initrd_addr_max limit");
         }
     }
 
@@ -171,12 +168,12 @@ pub fn boot_linux(
     // Check if 64-bit entry is supported
     // XLF_KERNEL_64 = 1
     if (header.xloadflags & 1) == 0 {
-        crate::println!("Kernel does not support 64-bit entry (XLF_KERNEL_64 not set)");
+        log::error!("Kernel does not support 64-bit entry (XLF_KERNEL_64 not set)");
         return Err(BootLinuxError::Unsupported);
     }
 
     // Jump to Kernel
-    crate::println!("Jumping to Linux kernel at 0x{:08X}", kernel_entry);
+    log::debug!("Jumping to Linux kernel at 0x{:08X}", kernel_entry);
     let entry_64 = kernel_entry as u64 + 0x200;
     unsafe {
         core::arch::asm!(

--- a/lace-platform/src/bios/mem.rs
+++ b/lace-platform/src/bios/mem.rs
@@ -2,15 +2,14 @@
 // Copyright (C) 2025, Canonical Ltd.
 // Authors: Mate Kukri <mate.kukri@canonical.com>
 
-//! BIOS Global Allocator
-
 use super::e820::{E820Entry, E820MemoryType, get_memory_map};
+use crate::mem::MemAttributes;
 use linked_list_allocator::LockedHeap;
 
 #[global_allocator]
-static ALLOCATOR: LockedHeap = LockedHeap::empty();
+static GLOBAL_ALLOCATOR: LockedHeap = LockedHeap::empty();
 
-pub fn init() {
+pub(super) fn init() {
     let mut entries = [E820Entry::default(); 64];
     let count = get_memory_map(&mut entries);
 
@@ -43,11 +42,29 @@ pub fn init() {
 
     if best_size > 0 {
         unsafe {
-            ALLOCATOR
+            GLOBAL_ALLOCATOR
                 .lock()
                 .init(best_start as *mut u8, best_size as usize);
         }
     } else {
         panic!("Could not find suitable memory for heap");
     }
+}
+
+pub const PAGE_SIZE: usize = 4096;
+
+pub enum MemoryType {}
+
+pub struct PageAllocation {}
+
+pub fn change_mem_attrs(
+    _addr_range: core::ops::Range<u64>,
+    _attrs: MemAttributes,
+) -> Result<(), crate::Error> {
+    // No-op on BIOS.
+    Ok(())
+}
+
+pub fn nx_required() -> bool {
+    false
 }

--- a/lace-platform/src/bios/mod.rs
+++ b/lace-platform/src/bios/mod.rs
@@ -32,13 +32,7 @@ impl From<fs::DiskError> for Error {
 
 #[panic_handler]
 fn panic_handler(info: &core::panic::PanicInfo) -> ! {
-    use core::fmt::Write as _;
-    let _ = writeln!(crate::console::stdout(), "PANIC: {}", info);
-    loop {
-        unsafe {
-            core::arch::asm!("hlt");
-        }
-    }
+    crate::console::panic(info)
 }
 
 #[unsafe(no_mangle)]

--- a/lace-platform/src/bios/mod.rs
+++ b/lace-platform/src/bios/mod.rs
@@ -9,12 +9,12 @@ use core::arch::global_asm;
 use lace_util::Display;
 use lace_util::smbios::{Smbios3EntryPoint, SmbiosEntryPoint};
 
-pub mod allocator;
 pub mod console;
 pub mod e820;
 pub mod fs;
 pub mod int;
 pub mod linux;
+pub mod mem;
 pub mod tpm2;
 
 pub use console::{print_impl, println_impl};
@@ -117,7 +117,7 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn lace_platform_bios_entry() -> ! {
-    allocator::init();
+    mem::init();
 
     unsafe extern "Rust" {
         fn lace_app_main() -> Result<(), Error>;

--- a/lace-platform/src/bios/mod.rs
+++ b/lace-platform/src/bios/mod.rs
@@ -17,8 +17,6 @@ pub mod linux;
 pub mod mem;
 pub mod tpm2;
 
-pub use console::{print_impl, println_impl};
-
 #[derive(Debug, Display)]
 pub enum Error {
     #[display("Disk error: {:?}")]
@@ -35,8 +33,6 @@ impl From<fs::DiskError> for Error {
 
 #[panic_handler]
 fn panic_handler(info: &core::panic::PanicInfo) -> ! {
-    // Force unlock console in case we panic while locked.
-    unsafe { console::OUTPUT.force_unlock() };
     println!("PANIC: {}", info);
     loop {
         unsafe {

--- a/lace-platform/src/bios/mod.rs
+++ b/lace-platform/src/bios/mod.rs
@@ -4,7 +4,6 @@
 
 //! BIOS platform abstractions.
 
-use crate::println;
 use core::arch::global_asm;
 use lace_util::Display;
 
@@ -33,7 +32,8 @@ impl From<fs::DiskError> for Error {
 
 #[panic_handler]
 fn panic_handler(info: &core::panic::PanicInfo) -> ! {
-    println!("PANIC: {}", info);
+    use core::fmt::Write as _;
+    let _ = writeln!(crate::console::stdout(), "PANIC: {}", info);
     loop {
         unsafe {
             core::arch::asm!("hlt");
@@ -44,14 +44,14 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
 #[unsafe(no_mangle)]
 pub extern "C" fn lace_platform_bios_entry() -> ! {
     mem::init();
+    crate::console::init();
 
     unsafe extern "Rust" {
         fn lace_app_main() -> Result<(), Error>;
     }
 
-    match unsafe { lace_app_main() } {
-        Ok(_) => (),
-        Err(e) => println!("Error: {}", e),
+    if let Err(e) = unsafe { lace_app_main() } {
+        log::error!("{}", e);
     }
 
     // Just hang if we fail to boot

--- a/lace-platform/src/bios/mod.rs
+++ b/lace-platform/src/bios/mod.rs
@@ -7,11 +7,11 @@
 use crate::println;
 use core::arch::global_asm;
 use lace_util::Display;
-use lace_util::smbios::{Smbios3EntryPoint, SmbiosEntryPoint};
 
 pub mod console;
 pub mod e820;
 pub mod fs;
+pub mod hwid;
 pub mod int;
 pub mod linux;
 pub mod mem;
@@ -30,76 +30,6 @@ pub enum Error {
 impl From<fs::DiskError> for Error {
     fn from(e: fs::DiskError) -> Self {
         Error::Disk(e)
-    }
-}
-
-/// Finds the EDID data.
-pub fn find_edid() -> Option<impl core::ops::Deref<Target = [u8]>> {
-    // TODO: Implement EDID finding via VBE (INT 10h AX=4F15h)
-    None::<&[u8]>
-}
-
-/// Finds SMBIOS tables by scanning the legacy memory range 0xF0000-0xFFFFF.
-pub fn find_smbios_tables() -> Option<(&'static [u8], &'static [u8])> {
-    let start = 0xF0000;
-    let end = 0xFFFFF;
-    let step = 16;
-
-    for addr in (start..=end).step_by(step) {
-        let ptr = addr as *const u8;
-        unsafe {
-            // Check for _SM3_ (SMBIOS 3.0)
-            if *ptr == b'_'
-                && *ptr.add(1) == b'S'
-                && *ptr.add(2) == b'M'
-                && *ptr.add(3) == b'3'
-                && *ptr.add(4) == b'_'
-            {
-                let entry = &*(ptr as *const Smbios3EntryPoint);
-                // TODO: Verify checksum
-                return Some((
-                    core::slice::from_raw_parts(ptr, core::mem::size_of::<Smbios3EntryPoint>()),
-                    core::slice::from_raw_parts(
-                        entry.table_address as *const u8,
-                        entry.table_maximum_size as usize,
-                    ),
-                ));
-            }
-            // Check for _SM_ (SMBIOS 2.1)
-            if *ptr == b'_' && *ptr.add(1) == b'S' && *ptr.add(2) == b'M' && *ptr.add(3) == b'_' {
-                let entry = &*(ptr as *const SmbiosEntryPoint);
-                // TODO: Verify checksum
-                return Some((
-                    core::slice::from_raw_parts(ptr, core::mem::size_of::<SmbiosEntryPoint>()),
-                    core::slice::from_raw_parts(
-                        entry.table_address as *const u8,
-                        entry.table_length as usize,
-                    ),
-                ));
-            }
-        }
-    }
-    None
-}
-
-pub mod dtb {
-    use lace_util::fdt::Fdt;
-
-    /// Finds an installed DTB in the system.
-    /// # Safety
-    /// This is not implemented for now.
-    pub unsafe fn find_dtb() -> Option<Fdt<'static>> {
-        todo!()
-    }
-
-    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-    pub struct DtbReceipt;
-
-    /// Installs a DTB in the system.
-    /// # Safety
-    /// This is not implemented for now.
-    pub unsafe fn install_dtb(_dtb: &[u8]) -> Result<DtbReceipt, super::Error> {
-        todo!()
     }
 }
 

--- a/lace-platform/src/bios/start.s
+++ b/lace-platform/src/bios/start.s
@@ -3,9 +3,9 @@
 # Long mode startup code
 # This code is entered after switching to long mode, but everything else
 # (GDT, IDT, page tables, stack) is still the temporary ones set up in the
-# 16-bit bootstrap.
+# 16-bit bootstrap.
 # This code sets up the permanent GDT, IDT, page tables, and stack
-# for the core long mode environment.
+# for the core long mode environment.
 
 .globl  _start, gdt, gdtr, idtr, stack, stack_top, pml4, pdp, pd
 
@@ -72,7 +72,7 @@ _start:
     # Call the BIOS entry point in Rust
     call lace_platform_bios_entry
 
-    # Hang here if main returns
+    # Hang here if main returns
 hang:
     hlt
     jmp hang
@@ -108,7 +108,7 @@ stack:
     .space 8192 # 8 KB stack
 stack_top:
 
-# Page tables
+# Page tables
 .align 4096
 pml4:
     .space 4096

--- a/lace-platform/src/bios/tpm2.rs
+++ b/lace-platform/src/bios/tpm2.rs
@@ -4,7 +4,7 @@
 //! BIOS TPM2 abstraction.
 
 use crate::Error;
-pub use crate::iface::tpm2::*;
+use crate::tpm2::*;
 
 /// This is a no-op, we probably don't really want to support TPM on BIOS.
 /// But if we end up having a native driver it might be worth wiring up the interface.

--- a/lace-platform/src/console.rs
+++ b/lace-platform/src/console.rs
@@ -91,6 +91,10 @@ impl Output for LockedConsole {
     fn set_position(&mut self, x: usize, y: usize) -> Result<(), crate::Error> {
         STDOUT.lock().set_position(x, y)
     }
+
+    fn clear_screen(&mut self) -> Result<(), crate::Error> {
+        STDOUT.lock().clear_screen()
+    }
 }
 
 /// Stateless handle implementing [`Input`] by locking the console
@@ -103,11 +107,36 @@ impl Input for LockedInput {
     }
 }
 
+/// Render the panic banner and halt forever.
+///
+/// Intended for bare-metal platforms that have no stderr; hosted runs
+/// simply do not call this and let the normal `std` panic machinery
+/// unwind or abort.
+pub fn panic(info: &dyn core::fmt::Display) -> ! {
+    use core::fmt::Write as _;
+    log::error!("{}", info);
+    let mut stdout = stdout();
+    let _ = stdout.clear_screen();
+    let _ = writeln!(stdout, "{0:=<80}", "");
+    let _ = writeln!(stdout, "{: ^80}", "PANIC");
+    let _ = writeln!(stdout, "{0:=<80}", "");
+    let _ = writeln!(stdout);
+    let _ = writeln!(stdout, "{}", info);
+    let _ = writeln!(stdout);
+    let _ = writeln!(stdout, "{0:-<80}", "");
+    let _ = writeln!(stdout, "System halted.");
+    loop {
+        core::hint::spin_loop();
+    }
+}
+
 /// Output driver
 pub trait Output: core::fmt::Write {
     fn get_position(&mut self) -> Result<(usize, usize), crate::Error>;
 
     fn set_position(&mut self, x: usize, y: usize) -> Result<(), crate::Error>;
+
+    fn clear_screen(&mut self) -> Result<(), crate::Error>;
 }
 
 /// Input driver

--- a/lace-platform/src/console.rs
+++ b/lace-platform/src/console.rs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+// Copyright (C) 2026, Canonical Ltd.
+// Authors: Mate Kukri <mate.kukri@canonical.com>
+//! lace-platform console interfaces.
+//!
+//! Each platform defines `OutputImpl` / `InputImpl` concrete types that
+//! forward to the underlying firmware console. They are held in static
+//! mutexes at this level, so no allocation or explicit init step is
+//! needed and the console is always available.
+//!
+//! Callers acquire the console via [`stdout`] / [`stdin`], which
+//! return stateless handles implementing the [`Output`] / [`Input`]
+//! traits. Each trait method takes the underlying mutex, performs one
+//! driver call, and releases it. Holding the lock only across a single
+//! driver call means arbitrary user code run between calls (e.g.
+//! `Display` impls invoked by `writeln!`) never executes with the lock
+//! held, so a panic from user code cannot leave the console mutex in
+//! a locked state.
+
+use crate::p::console::{InputImpl, OutputImpl};
+use spin::Mutex;
+
+static STDOUT: Mutex<OutputImpl> = Mutex::new(OutputImpl::new());
+static STDIN: Mutex<InputImpl> = Mutex::new(InputImpl::new());
+
+/// Handle to the platform stdout.
+pub fn stdout() -> LockedConsole {
+    LockedConsole
+}
+
+/// Handle to the platform stdin.
+pub fn stdin() -> LockedInput {
+    LockedInput
+}
+
+/// Stateless handle implementing [`Output`] by locking the console
+/// mutex per call.
+pub struct LockedConsole;
+
+impl core::fmt::Write for LockedConsole {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        STDOUT.lock().write_str(s)
+    }
+}
+
+impl Output for LockedConsole {
+    fn get_position(&mut self) -> Result<(usize, usize), crate::Error> {
+        STDOUT.lock().get_position()
+    }
+
+    fn set_position(&mut self, x: usize, y: usize) -> Result<(), crate::Error> {
+        STDOUT.lock().set_position(x, y)
+    }
+}
+
+/// Stateless handle implementing [`Input`] by locking the console
+/// mutex per call.
+pub struct LockedInput;
+
+impl Input for LockedInput {
+    fn wait_input(&mut self) -> Result<InputEvent, crate::Error> {
+        STDIN.lock().wait_input()
+    }
+}
+
+/// Output driver
+pub trait Output: core::fmt::Write {
+    fn get_position(&mut self) -> Result<(usize, usize), crate::Error>;
+
+    fn set_position(&mut self, x: usize, y: usize) -> Result<(), crate::Error>;
+}
+
+/// Input driver
+pub trait Input {
+    /// Wait until an input event
+    fn wait_input(&mut self) -> Result<InputEvent, crate::Error>;
+}
+
+/// Input event
+pub struct InputEvent {
+    pub char: char,
+    pub scancode: u8,
+}

--- a/lace-platform/src/console.rs
+++ b/lace-platform/src/console.rs
@@ -18,12 +18,52 @@
 //! a locked state.
 
 use crate::p::console::{InputImpl, OutputImpl};
+use log::{LevelFilter, Log, Metadata, Record};
 use spin::Mutex;
 
 static STDOUT: Mutex<OutputImpl> = Mutex::new(OutputImpl::new());
 static STDIN: Mutex<InputImpl> = Mutex::new(InputImpl::new());
 
+/// Initialize the console subsystem.
+pub fn init() {
+    let _ = log::set_logger(&LOGGER);
+    log::set_max_level(if cfg!(debug_assertions) {
+        LevelFilter::Debug
+    } else {
+        LevelFilter::Info
+    });
+}
+
+/// `log::Log` implementation that writes formatted log records to stdout.
+struct ConsoleLogger;
+
+static LOGGER: ConsoleLogger = ConsoleLogger;
+
+impl Log for ConsoleLogger {
+    fn enabled(&self, _: &Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record) {
+        use core::fmt::Write as _;
+        let _ = writeln!(
+            stdout(),
+            "[{} {}] {}",
+            record.level(),
+            record.target(),
+            record.args()
+        );
+    }
+
+    fn flush(&self) {}
+}
+
 /// Handle to the platform stdout.
+///
+/// Direct access to stdout is intended for interactive UI (menu
+/// rendering, cursor positioning, ...). General program output should
+/// go through the `log` crate, which the console logger routes back
+/// through here.
 pub fn stdout() -> LockedConsole {
     LockedConsole
 }

--- a/lace-platform/src/efi/console.rs
+++ b/lace-platform/src/efi/console.rs
@@ -33,6 +33,11 @@ impl Output for OutputImpl {
         uefi::system::with_stdout(|stdout| stdout.set_cursor_position(x, y))?;
         Ok(())
     }
+
+    fn clear_screen(&mut self) -> Result<(), crate::Error> {
+        uefi::system::with_stdout(|stdout| stdout.clear())?;
+        Ok(())
+    }
 }
 
 pub struct InputImpl {

--- a/lace-platform/src/efi/console.rs
+++ b/lace-platform/src/efi/console.rs
@@ -4,79 +4,100 @@
 
 //! EFI Services for Printing and Input
 
-use core::fmt::{self, Write};
+use crate::console::{Input, InputEvent, Output};
 use uefi::proto::console::text::{Key, ScanCode};
 
-/// Platform specific text output
-pub fn print_impl(args: fmt::Arguments<'_>) {
-    uefi::system::with_stdout(|stdout| {
-        let _ = write!(stdout, "{}", args);
-    });
+pub struct OutputImpl {
+    _private: (),
 }
 
-/// Platform specific text output with newline
-pub fn println_impl(args: fmt::Arguments<'_>) {
-    uefi::system::with_stdout(|stdout| {
-        let _ = writeln!(stdout, "{}", args);
-    });
+impl OutputImpl {
+    #[allow(clippy::new_without_default)]
+    pub const fn new() -> Self {
+        Self { _private: () }
+    }
 }
 
-/// Keyboard event structure containing character and scancode
-#[derive(Debug, Clone, Copy)]
-pub struct KeyEvent {
-    pub char: char,
-    pub scancode: u8,
+impl core::fmt::Write for OutputImpl {
+    fn write_str(&mut self, s: &str) -> Result<(), core::fmt::Error> {
+        uefi::system::with_stdout(|stdout| stdout.write_str(s)).map_err(|_| core::fmt::Error)
+    }
 }
 
-/// Read a single keystroke from the keyboard (blocking)
-pub fn read_key() -> Result<KeyEvent, uefi::Error> {
-    // NOTE: if this is NULL the firmware is sufficiently broken that we should just panic
-    let wait_for_key_event = uefi::system::with_stdin(|stdin| stdin.wait_for_key_event()).unwrap();
-    // Wait for input to be available
-    uefi::boot::wait_for_event(&mut [wait_for_key_event])
-        .map_err(|e| e.to_err_without_payload())?;
-    // Read the key
-    let key_opt = uefi::system::with_stdin(|stdin| stdin.read_key())?;
-    match key_opt {
-        Some(key) => {
-            let (c, sc) = match key {
-                // The firmware did not provide scancodes for printable characters
-                Key::Printable(c) => (char::from(c), 0),
-                // Translate UEFI scancodes to Scancode set 1
-                // It is questionable if this is what we want to standardize on,
-                // maybe we should translate to Linux input layer codes instead?
-                Key::Special(ScanCode::NULL) => ('\0', 0),
-                Key::Special(ScanCode::UP) => ('\0', 0x48),
-                Key::Special(ScanCode::DOWN) => ('\0', 0x50),
-                Key::Special(ScanCode::RIGHT) => ('\0', 0x4D),
-                Key::Special(ScanCode::LEFT) => ('\0', 0x4B),
-                Key::Special(ScanCode::HOME) => ('\0', 0x47),
-                Key::Special(ScanCode::END) => ('\0', 0x4F),
-                Key::Special(ScanCode::INSERT) => ('\0', 0x52),
-                Key::Special(ScanCode::DELETE) => ('\x7F', 0x53), // DEL
-                Key::Special(ScanCode::PAGE_UP) => ('\0', 0x49),
-                Key::Special(ScanCode::PAGE_DOWN) => ('\0', 0x51),
-                Key::Special(ScanCode::FUNCTION_1) => ('\0', 0x3B),
-                Key::Special(ScanCode::FUNCTION_2) => ('\0', 0x3C),
-                Key::Special(ScanCode::FUNCTION_3) => ('\0', 0x3D),
-                Key::Special(ScanCode::FUNCTION_4) => ('\0', 0x3E),
-                Key::Special(ScanCode::FUNCTION_5) => ('\0', 0x3F),
-                Key::Special(ScanCode::FUNCTION_6) => ('\0', 0x40),
-                Key::Special(ScanCode::FUNCTION_7) => ('\0', 0x41),
-                Key::Special(ScanCode::FUNCTION_8) => ('\0', 0x42),
-                Key::Special(ScanCode::FUNCTION_9) => ('\0', 0x43),
-                Key::Special(ScanCode::FUNCTION_10) => ('\0', 0x44),
-                Key::Special(ScanCode::FUNCTION_11) => ('\0', 0x57),
-                Key::Special(ScanCode::FUNCTION_12) => ('\0', 0x58),
-                Key::Special(ScanCode::ESCAPE) => ('\0', 0x01),
-                // Pass along the firmware scan-code (likely not useful)
-                Key::Special(sc) => ('\0', sc.0 as u8),
-            };
-            Ok(KeyEvent {
-                char: c,
-                scancode: sc,
-            })
+impl Output for OutputImpl {
+    fn get_position(&mut self) -> Result<(usize, usize), crate::Error> {
+        Ok(uefi::system::with_stdout(|stdout| stdout.cursor_position()))
+    }
+
+    fn set_position(&mut self, x: usize, y: usize) -> Result<(), crate::Error> {
+        uefi::system::with_stdout(|stdout| stdout.set_cursor_position(x, y))?;
+        Ok(())
+    }
+}
+
+pub struct InputImpl {
+    _private: (),
+}
+
+impl InputImpl {
+    #[allow(clippy::new_without_default)]
+    pub const fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+impl Input for InputImpl {
+    /// Wait for a single input event
+    fn wait_input(&mut self) -> Result<InputEvent, crate::Error> {
+        // NOTE: if this is NULL the firmware is sufficiently broken that we should just panic
+        let wait_for_key_event =
+            uefi::system::with_stdin(|stdin| stdin.wait_for_key_event()).unwrap();
+        // Wait for input to be available
+        uefi::boot::wait_for_event(&mut [wait_for_key_event])
+            .map_err(|e| e.to_err_without_payload())?;
+        // Read the key
+        let key_opt = uefi::system::with_stdin(|stdin| stdin.read_key())?;
+        match key_opt {
+            Some(key) => {
+                let (c, sc) = match key {
+                    // The firmware did not provide scancodes for printable characters
+                    Key::Printable(c) => (char::from(c), 0),
+                    // Translate UEFI scancodes to Scancode set 1
+                    // It is questionable if this is what we want to standardize on,
+                    // maybe we should translate to Linux input layer codes instead?
+                    Key::Special(ScanCode::NULL) => ('\0', 0),
+                    Key::Special(ScanCode::UP) => ('\0', 0x48),
+                    Key::Special(ScanCode::DOWN) => ('\0', 0x50),
+                    Key::Special(ScanCode::RIGHT) => ('\0', 0x4D),
+                    Key::Special(ScanCode::LEFT) => ('\0', 0x4B),
+                    Key::Special(ScanCode::HOME) => ('\0', 0x47),
+                    Key::Special(ScanCode::END) => ('\0', 0x4F),
+                    Key::Special(ScanCode::INSERT) => ('\0', 0x52),
+                    Key::Special(ScanCode::DELETE) => ('\x7F', 0x53), // DEL
+                    Key::Special(ScanCode::PAGE_UP) => ('\0', 0x49),
+                    Key::Special(ScanCode::PAGE_DOWN) => ('\0', 0x51),
+                    Key::Special(ScanCode::FUNCTION_1) => ('\0', 0x3B),
+                    Key::Special(ScanCode::FUNCTION_2) => ('\0', 0x3C),
+                    Key::Special(ScanCode::FUNCTION_3) => ('\0', 0x3D),
+                    Key::Special(ScanCode::FUNCTION_4) => ('\0', 0x3E),
+                    Key::Special(ScanCode::FUNCTION_5) => ('\0', 0x3F),
+                    Key::Special(ScanCode::FUNCTION_6) => ('\0', 0x40),
+                    Key::Special(ScanCode::FUNCTION_7) => ('\0', 0x41),
+                    Key::Special(ScanCode::FUNCTION_8) => ('\0', 0x42),
+                    Key::Special(ScanCode::FUNCTION_9) => ('\0', 0x43),
+                    Key::Special(ScanCode::FUNCTION_10) => ('\0', 0x44),
+                    Key::Special(ScanCode::FUNCTION_11) => ('\0', 0x57),
+                    Key::Special(ScanCode::FUNCTION_12) => ('\0', 0x58),
+                    Key::Special(ScanCode::ESCAPE) => ('\0', 0x01),
+                    // Pass along the firmware scan-code (likely not useful)
+                    Key::Special(sc) => ('\0', sc.0 as u8),
+                };
+                Ok(InputEvent {
+                    char: c,
+                    scancode: sc,
+                })
+            }
+            None => unreachable!(), // should not happen after wait_for_key_event
         }
-        None => unreachable!(), // should not happen after wait_for_key_event
     }
 }

--- a/lace-platform/src/efi/dtb.rs
+++ b/lace-platform/src/efi/dtb.rs
@@ -3,11 +3,11 @@
 // Authors: Mate Kukri <mate.kukri@canonical.com>
 //! Device tree related EFI functionality.
 
-use crate::efi::mem::{
-    MemoryType, PageAllocation, PageAllocationConstraint, PageAllocationIface, page_count,
-};
 use crate::efi::open_protocol_exclusive;
 use crate::efi::proto::dt_fixup;
+use crate::mem::{
+    MemoryType, PageAllocation, PageAllocationConstraint, PageAllocationIface, page_count,
+};
 
 use lace_util::fdt::Fdt;
 

--- a/lace-platform/src/efi/fs.rs
+++ b/lace-platform/src/efi/fs.rs
@@ -26,14 +26,14 @@ pub struct UefiFilesystem {
 impl UefiFilesystem {
     /// Create a new UEFI filesystem from a handle.
     pub fn new(handle: uefi::Handle) -> Result<Self, uefi::Error> {
-        crate::debugln!(
+        log::debug!(
             "[FS] Attempting to open UEFI SimpleFileSystem on handle {:?}",
             handle
         );
         let proto = uefi::boot::open_protocol_exclusive::<uefi::proto::media::fs::SimpleFileSystem>(
             handle,
         )?;
-        crate::debugln!("[FS] Successfully opened UEFI SimpleFileSystem");
+        log::debug!("[FS] Successfully opened UEFI SimpleFileSystem");
         Ok(Self { proto })
     }
 }
@@ -241,7 +241,7 @@ fn is_logical_partition(handle: uefi::Handle) -> bool {
 fn classify_handle(handle: uefi::Handle, result: &mut DiscoveredStorage) {
     // Try UEFI SimpleFileSystem first (FAT/FAT32 on ESP)
     if let Ok(fs) = UefiFilesystem::new(handle) {
-        crate::debugln!("[EFI] Found SimpleFileSystem on handle {:?}", handle);
+        log::debug!("[EFI] Found SimpleFileSystem on handle {:?}", handle);
         result.filesystems.push(Box::new(fs));
         return;
     }
@@ -250,11 +250,11 @@ fn classify_handle(handle: uefi::Handle, result: &mut DiscoveredStorage) {
     if is_logical_partition(handle) {
         match UefiBlockDevice::new(handle) {
             Ok(dev) => {
-                crate::debugln!("[EFI] Found partition block device: {:?}", handle);
+                log::debug!("[EFI] Found partition block device: {:?}", handle);
                 result.partitions.push(Box::new(dev));
             }
             Err(e) => {
-                crate::debugln!("[EFI] Failed to open DiskIO on {:?}: {:?}", handle, e);
+                log::debug!("[EFI] Failed to open DiskIO on {:?}: {:?}", handle, e);
             }
         }
     }
@@ -267,7 +267,7 @@ fn enumerate_disk_io_handles() -> Vec<uefi::Handle> {
     )) {
         Ok(h) => h.to_vec(),
         Err(e) => {
-            crate::debugln!("[EFI] Failed to enumerate DiskIO handles: {:?}", e);
+            log::debug!("[EFI] Failed to enumerate DiskIO handles: {:?}", e);
             Vec::new()
         }
     }
@@ -310,7 +310,7 @@ fn get_parent_device_path_bytes(handle: uefi::Handle) -> Option<Vec<u8>> {
 /// Discover all storage.
 pub fn discover_storage() -> DiscoveredStorage {
     let handles = enumerate_disk_io_handles();
-    crate::debugln!("[EFI] Found {} DiskIO handles", handles.len());
+    log::debug!("[EFI] Found {} DiskIO handles", handles.len());
 
     let mut result = DiscoveredStorage::new();
 
@@ -336,25 +336,25 @@ pub fn discover_boot_storage() -> DiscoveredStorage {
         ) {
             Ok(li) => li,
             Err(e) => {
-                crate::debugln!("[EFI] Failed to open LoadedImage: {:?}", e);
+                log::debug!("[EFI] Failed to open LoadedImage: {:?}", e);
                 return result;
             }
         };
         match li.device() {
             Some(h) => h,
             None => {
-                crate::debugln!("[EFI] LoadedImage has no device handle");
+                log::debug!("[EFI] LoadedImage has no device handle");
                 return result;
             }
         }
     };
 
-    crate::debugln!("[EFI] Boot device handle: {:?}", boot_device_handle);
+    log::debug!("[EFI] Boot device handle: {:?}", boot_device_handle);
 
     let boot_parent = get_parent_device_path_bytes(boot_device_handle);
 
     let handles = enumerate_disk_io_handles();
-    crate::debugln!(
+    log::debug!(
         "[EFI] Scanning {} handles for boot disk siblings",
         handles.len()
     );

--- a/lace-platform/src/efi/hwid.rs
+++ b/lace-platform/src/efi/hwid.rs
@@ -3,13 +3,16 @@
 // Authors: Mate Kukri <mate.kukri@canonical.com>
 //! Device tree related EFI functionality.
 
-use crate::efi::open_protocol_exclusive;
-use crate::efi::proto::dt_fixup;
+use super::{
+    open_first_protocol_exclusive,
+    proto::{dt_fixup::DtFixupProtocol, edid_discovered::EdidDiscoveredProtocol},
+};
 use crate::mem::{
     MemoryType, PageAllocation, PageAllocationConstraint, PageAllocationIface, page_count,
 };
-
+use core::ops::Deref;
 use lace_util::fdt::Fdt;
+use lace_util::smbios::{Smbios3EntryPoint, SmbiosEntryPoint};
 
 /// EFI configuration table pointing to a device tree.
 /// The DTB must be contained in memory of type EfiACPIReclaimMemory.
@@ -43,7 +46,7 @@ impl Drop for DtbReceipt {
 /// which other code might have references to. The caller must ensure that
 /// no such references exist.
 pub unsafe fn install_dtb(dtb: &[u8]) -> Result<impl Drop, uefi::Error> {
-    let buf: PageAllocation = match open_protocol_exclusive::<dt_fixup::DtFixupProtocol>() {
+    let buf: PageAllocation = match open_first_protocol_exclusive::<DtFixupProtocol>() {
         Ok(mut proto) => proto.fixup_owned(dtb)?,
         Err(_) => PageAllocation::new_init_prefix(
             PageAllocationConstraint::AnyAddress,
@@ -74,10 +77,68 @@ pub unsafe fn install_dtb(dtb: &[u8]) -> Result<impl Drop, uefi::Error> {
 /// The returned `Fdt` is valid as long as the DTB configuration table remains installed
 /// in the EFI system table. The caller must ensure this is the case.
 pub unsafe fn find_dtb() -> Option<Fdt<'static>> {
-    let ptr: *const u8 = super::find_config_table(DTB_TABLE_GUID)?;
+    let ptr: *const u8 = find_config_table(DTB_TABLE_GUID)?;
     unsafe {
         // SAFETY: The pointer from the configuration table is valid as long as the table is installed,
         // which is guaranteed by the caller.
         Fdt::from_ptr(ptr).ok()
     }
+}
+
+/// Opaque reference to EDID data obtained from the EDID Discovered Protocol.
+struct EdidRef(uefi::boot::ScopedProtocol<EdidDiscoveredProtocol>);
+
+impl Deref for EdidRef {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.0.edid_data()
+    }
+}
+
+/// Finds the first EDID Discovered Protocol instance and returns the EDID data attached to it.
+pub fn find_edid() -> Option<impl Deref<Target = [u8]>> {
+    open_first_protocol_exclusive::<EdidDiscoveredProtocol>()
+        .ok()
+        .map(EdidRef)
+}
+
+/// Finds SMBIOS tables in the UEFI configuration tables.
+pub fn find_smbios_tables() -> Option<(&'static [u8], &'static [u8])> {
+    unsafe {
+        if let Some(ptr) =
+            find_config_table::<Smbios3EntryPoint>(uefi::table::cfg::ConfigTableEntry::SMBIOS3_GUID)
+            && (*ptr).anchor_string.eq(b"_SM3_")
+        {
+            return Some((
+                core::slice::from_raw_parts(ptr as *const u8, size_of::<Smbios3EntryPoint>()),
+                core::slice::from_raw_parts(
+                    (*ptr).table_address as *const u8,
+                    (*ptr).table_maximum_size as _,
+                ),
+            ));
+        }
+        if let Some(ptr) =
+            find_config_table::<SmbiosEntryPoint>(uefi::table::cfg::ConfigTableEntry::SMBIOS_GUID)
+            && (*ptr).anchor_string.eq(b"_SM_")
+        {
+            return Some((
+                core::slice::from_raw_parts(ptr as *const u8, size_of::<SmbiosEntryPoint>()),
+                core::slice::from_raw_parts((*ptr).table_address as _, (*ptr).table_length as _),
+            ));
+        }
+    }
+    None
+}
+
+/// Finds a configuration table by its GUID.
+fn find_config_table<T>(guid: uefi::Guid) -> Option<*const T> {
+    uefi::system::with_config_table(|tables| {
+        for table in tables.iter() {
+            if table.guid.eq(&guid) && !table.address.is_null() {
+                return Some(table.address as *const T);
+            }
+        }
+        None
+    })
 }

--- a/lace-platform/src/efi/image.rs
+++ b/lace-platform/src/efi/image.rs
@@ -79,7 +79,7 @@ impl LaceLoadedImage {
         } else {
             MemAttributes::empty()
         };
-        crate::debugln!("Setting base memory attributes: {:?}", base_attrs);
+        log::debug!("Setting base memory attributes: {:?}", base_attrs);
         mem::change_mem_attrs(image_base..(image_base + alloc_size as u64), base_attrs)
             .map_err(LaceLoadImageError::MemoryAttributeError)?;
 
@@ -93,7 +93,7 @@ impl LaceLoadedImage {
                 pe.nt_hdrs.optional_header.size_of_headers as u64,
                 mem::PAGE_SIZE as u64
             );
-            crate::debugln!("Setting PE header memory attributes: WRITE_PROTECT | EXECUTE_PROTECT");
+            log::debug!("Setting PE header memory attributes: WRITE_PROTECT | EXECUTE_PROTECT");
             mem::change_mem_attrs(
                 image_base..(image_base + pe_header_size),
                 MemAttributes::WRITE_PROTECT | MemAttributes::EXECUTE_PROTECT,
@@ -136,7 +136,7 @@ impl LaceLoadedImage {
                     attrs |= MemAttributes::EXECUTE_PROTECT;
                 }
 
-                crate::debugln!(
+                log::debug!(
                     "Setting section memory attributes for section at {:#x}-{:#x}: {:?}",
                     sec_start,
                     sec_end,
@@ -147,7 +147,7 @@ impl LaceLoadedImage {
             }
         }
 
-        crate::debugln!(
+        log::debug!(
             "Loaded EFI image at {:p}, size {:#x}",
             pages.as_ptr(),
             pe.nt_hdrs.optional_header.size_of_image

--- a/lace-platform/src/efi/image.rs
+++ b/lace-platform/src/efi/image.rs
@@ -3,8 +3,8 @@
 // Authors: Mate Kukri <mate.kukri@canonical.com>
 //! EFI image loading.
 
-use super::mem::{
-    MemoryType, PageAllocation, PageAllocationConstraint, PageAllocationIface, page_count,
+use crate::mem::{
+    self, MemAttributes, MemoryType, PageAllocation, PageAllocationConstraint, PageAllocationIface,
 };
 use core::ffi::c_void;
 use lace_util::Display;
@@ -49,15 +49,15 @@ impl LaceLoadedImage {
             & peimage::DLLCHARACTERISTICS_NX_COMPAT
             != 0;
 
-        if super::mem::nx_required() && !nx_compat {
+        if crate::mem::nx_required() && !nx_compat {
             // NX is required but the image is not NX compatible.
             return Err(LaceLoadImageError::NxPolicyViolation);
         }
         // NX compatibility requires page-aligned image size.
         if nx_compat
-            && ((pe.nt_hdrs.optional_header.section_alignment as usize) < super::mem::PAGE_SIZE
+            && ((pe.nt_hdrs.optional_header.section_alignment as usize) < mem::PAGE_SIZE
                 || !(pe.nt_hdrs.optional_header.section_alignment as usize)
-                    .is_multiple_of(super::mem::PAGE_SIZE))
+                    .is_multiple_of(mem::PAGE_SIZE))
         {
             return Err(LaceLoadImageError::NxPolicyViolation);
         }
@@ -65,22 +65,22 @@ impl LaceLoadedImage {
         let mut pages = PageAllocation::new_zeroed(
             PageAllocationConstraint::AnyAddress,
             Some(MemoryType::LOADER_CODE),
-            page_count(pe.nt_hdrs.optional_header.size_of_image as usize),
+            mem::page_count(pe.nt_hdrs.optional_header.size_of_image as usize),
             None,
         )
         .map_err(LaceLoadImageError::MemoryAllocationError)?;
 
         let image_base = pages.as_ptr() as u64;
-        let alloc_size = pages.pages() * super::mem::PAGE_SIZE;
+        let alloc_size = pages.pages() * mem::PAGE_SIZE;
 
         // If the image is NX compatible set the base policy as EXECUTE_PROTECT, otherwise no protection.
         let base_attrs = if nx_compat {
-            super::mem::MemAttributes::EXECUTE_PROTECT
+            MemAttributes::EXECUTE_PROTECT
         } else {
-            super::mem::MemAttributes::empty()
+            MemAttributes::empty()
         };
         crate::debugln!("Setting base memory attributes: {:?}", base_attrs);
-        super::mem::change_mem_attrs(image_base..(image_base + alloc_size as u64), base_attrs)
+        mem::change_mem_attrs(image_base..(image_base + alloc_size as u64), base_attrs)
             .map_err(LaceLoadImageError::MemoryAttributeError)?;
 
         // Relocate the image into the allocated pages.
@@ -91,13 +91,12 @@ impl LaceLoadedImage {
             // Set PE header as read-only.
             let pe_header_size = align_up!(
                 pe.nt_hdrs.optional_header.size_of_headers as u64,
-                super::mem::PAGE_SIZE as u64
+                mem::PAGE_SIZE as u64
             );
             crate::debugln!("Setting PE header memory attributes: WRITE_PROTECT | EXECUTE_PROTECT");
-            super::mem::change_mem_attrs(
+            mem::change_mem_attrs(
                 image_base..(image_base + pe_header_size),
-                super::mem::MemAttributes::WRITE_PROTECT
-                    | super::mem::MemAttributes::EXECUTE_PROTECT,
+                MemAttributes::WRITE_PROTECT | MemAttributes::EXECUTE_PROTECT,
             )
             .map_err(LaceLoadImageError::MemoryAttributeError)?;
 
@@ -109,10 +108,10 @@ impl LaceLoadedImage {
                 let (shdr, _) = section.map_err(LaceLoadImageError::PeError)?;
                 let sec_start = image_base + shdr.virtual_address as u64;
                 let sec_end =
-                    sec_start + align_up!(shdr.virtual_size as u64, super::mem::PAGE_SIZE as u64);
+                    sec_start + align_up!(shdr.virtual_size as u64, mem::PAGE_SIZE as u64);
 
                 // NX requires section start to be page-aligned.
-                if sec_start != align_up!(sec_start, super::mem::PAGE_SIZE as u64) {
+                if sec_start != align_up!(sec_start, mem::PAGE_SIZE as u64) {
                     return Err(LaceLoadImageError::NxPolicyViolation);
                 }
                 // NX requires no W&X sections.
@@ -123,18 +122,18 @@ impl LaceLoadedImage {
                 }
 
                 // Set section attributes
-                let mut attrs = super::mem::MemAttributes::empty();
+                let mut attrs = MemAttributes::empty();
                 if shdr.characteristics & peimage::SCN_MEM_READ == 0 {
                     // Not readable
-                    attrs |= super::mem::MemAttributes::READ_PROTECT;
+                    attrs |= MemAttributes::READ_PROTECT;
                 }
                 if shdr.characteristics & peimage::SCN_MEM_WRITE == 0 {
                     // Not writable
-                    attrs |= super::mem::MemAttributes::WRITE_PROTECT;
+                    attrs |= MemAttributes::WRITE_PROTECT;
                 }
                 if shdr.characteristics & peimage::SCN_MEM_EXECUTE == 0 {
                     // Not executable
-                    attrs |= super::mem::MemAttributes::EXECUTE_PROTECT;
+                    attrs |= MemAttributes::EXECUTE_PROTECT;
                 }
 
                 crate::debugln!(
@@ -143,7 +142,7 @@ impl LaceLoadedImage {
                     sec_end,
                     attrs
                 );
-                super::mem::change_mem_attrs(sec_start..sec_end, attrs)
+                mem::change_mem_attrs(sec_start..sec_end, attrs)
                     .map_err(LaceLoadImageError::MemoryAttributeError)?;
             }
         }

--- a/lace-platform/src/efi/mem.rs
+++ b/lace-platform/src/efi/mem.rs
@@ -126,7 +126,8 @@ pub fn change_mem_attrs(
     addr_range: core::ops::Range<u64>,
     attrs: MemAttributes,
 ) -> Result<(), uefi::Error> {
-    let Ok(mem_prot) = super::open_protocol_exclusive::<uefi::proto::security::MemoryProtection>()
+    let Ok(mem_prot) =
+        super::open_first_protocol_exclusive::<uefi::proto::security::MemoryProtection>()
     else {
         crate::debugln!(
             "EFI Memory Protection Protocol not available, cannot change memory attributes"
@@ -188,7 +189,7 @@ pub fn nx_required() -> bool {
 }
 
 /// Initialize UEFI memory management utilities.
-pub(super) fn efi_mem_init() {
+pub(super) fn init() {
     // Determine if NX is required by the firmware.
     // We use the NX_COMPAT flag in the currently running image as a proxy.
     // 1. If an NX_COMPAT image is already running the firmware _might_ enforce NX thus we should too.

--- a/lace-platform/src/efi/mem.rs
+++ b/lace-platform/src/efi/mem.rs
@@ -106,7 +106,7 @@ impl Drop for PageAllocation {
         // Set memory as RWX before freeing. This is a workaround for an EDK2 bug
         // where freeing memory with certain attributes set can cause a crash.
         // See: https://github.com/rhboot/shim/blob/c4665d282072df2ed8ab6ae1d5fa0de41e5db02f/loader-proto.c#L194
-        crate::debugln!("WORKAROUND: Clearing memory attributes before freeing pages");
+        log::debug!("WORKAROUND: Clearing memory attributes before freeing pages");
         let _ = change_mem_attrs(
             self.as_ptr() as u64..(self.as_ptr() as u64 + (self.pages * PAGE_SIZE) as u64),
             MemAttributes::empty(),
@@ -129,14 +129,14 @@ pub fn change_mem_attrs(
     let Ok(mem_prot) =
         super::open_first_protocol_exclusive::<uefi::proto::security::MemoryProtection>()
     else {
-        crate::debugln!(
+        log::debug!(
             "EFI Memory Protection Protocol not available, cannot change memory attributes"
         );
         return Ok(());
     };
     let (set, clear) = lace_mem_attrs_to_uefi(&attrs);
     if !set.is_empty() {
-        crate::debugln!(
+        log::debug!(
             "Setting EFI memory attributes for range {:x}-{:x} to {:?}",
             addr_range.start,
             addr_range.end,
@@ -145,7 +145,7 @@ pub fn change_mem_attrs(
         mem_prot.set_memory_attributes(addr_range.clone(), set)?;
     }
     if !clear.is_empty() {
-        crate::debugln!(
+        log::debug!(
             "Clearing EFI memory attributes for range {:x}-{:x} to {:?}",
             addr_range.start,
             addr_range.end,
@@ -209,6 +209,6 @@ pub(super) fn init() {
     let nx_required = own_pe.nt_hdrs.optional_header.dll_characteristics
         & peimage::DLLCHARACTERISTICS_NX_COMPAT
         != 0;
-    crate::debugln!("EFI memory: NX required = {}", nx_required);
+    log::debug!("EFI memory: NX required = {}", nx_required);
     NX_REQUIRED.call_once(|| nx_required);
 }

--- a/lace-platform/src/efi/mem.rs
+++ b/lace-platform/src/efi/mem.rs
@@ -3,23 +3,16 @@
 // Authors: Mate Kukri <mate.kukri@canonical.com>
 //! UEFI memory management utilities.
 
+use crate::mem::{MemAttributes, PageAllocationConstraint, PageAllocationIface};
+use core::ptr::NonNull;
 use lace_util::peimage;
 use uefi::boot::ScopedProtocol;
-
-pub use crate::iface::mem::{MemAttributes, PageAllocationConstraint, PageAllocationIface};
-use core::ptr::NonNull;
 
 /// Type alias for UEFI physical addresses.
 pub type Address = u64;
 
 /// Page size used by the UEFI boot services page allocator.
 pub const PAGE_SIZE: usize = uefi::boot::PAGE_SIZE;
-
-/// Computes the number of pages required to hold a given size in bytes,
-/// rounding up to the nearest page.
-pub const fn page_count(size: usize) -> usize {
-    size.div_ceil(PAGE_SIZE)
-}
 
 /// Type alias for UEFI boot services page allocation types.
 pub type AllocateType = uefi::boot::AllocateType;

--- a/lace-platform/src/efi/mod.rs
+++ b/lace-platform/src/efi/mod.rs
@@ -15,8 +15,10 @@ pub mod tpm2;
 /// Platform specific error type
 pub use uefi::Error;
 
-/// Re-export common filesystem types from the base module
-pub use super::fs::base::{BlockDevice, DirEntry, File, Filesystem, FsError};
+#[panic_handler]
+fn panic_handler(info: &core::panic::PanicInfo) -> ! {
+    crate::console::panic(info)
+}
 
 /// Opens the first instance of the given protocol in exclusive mode.
 fn open_first_protocol_exclusive<T: uefi::proto::Protocol>()

--- a/lace-platform/src/efi/mod.rs
+++ b/lace-platform/src/efi/mod.rs
@@ -3,19 +3,14 @@
 // Authors: Mate Kukri <mate.kukri@canonical.com>
 //! UEFI platform abstractions.
 
-use core::ops::Deref;
-use lace_util::smbios::{Smbios3EntryPoint, SmbiosEntryPoint};
-
 pub mod console;
-pub mod dtb;
 pub mod fs;
+pub mod hwid;
 pub mod image;
 pub mod linux;
 pub mod mem;
 pub mod proto;
 pub mod tpm2;
-
-use proto::edid_discovered::EdidDiscoveredProtocol;
 
 /// Platform specific error type
 pub use uefi::Error;
@@ -24,7 +19,7 @@ pub use uefi::Error;
 pub use super::fs::base::{BlockDevice, DirEntry, File, Filesystem, FsError};
 
 /// Opens the first instance of the given protocol in exclusive mode.
-pub fn open_protocol_exclusive<T: uefi::proto::Protocol>()
+fn open_first_protocol_exclusive<T: uefi::proto::Protocol>()
 -> Result<uefi::boot::ScopedProtocol<T>, uefi::Error> {
     let handle_buf =
         uefi::boot::locate_handle_buffer(uefi::boot::SearchType::ByProtocol(&T::GUID))?;
@@ -32,69 +27,11 @@ pub fn open_protocol_exclusive<T: uefi::proto::Protocol>()
     uefi::boot::open_protocol_exclusive::<T>(handle_buf[0])
 }
 
-/// Finds a configuration table by its GUID.
-pub fn find_config_table<T>(guid: uefi::Guid) -> Option<*const T> {
-    uefi::system::with_config_table(|tables| {
-        for table in tables.iter() {
-            if table.guid.eq(&guid) && !table.address.is_null() {
-                return Some(table.address as *const T);
-            }
-        }
-        None
-    })
-}
-
-/// Opaque reference to EDID data obtained from the EDID Discovered Protocol.
-struct EdidRef(uefi::boot::ScopedProtocol<EdidDiscoveredProtocol>);
-
-impl Deref for EdidRef {
-    type Target = [u8];
-
-    fn deref(&self) -> &Self::Target {
-        self.0.edid_data()
-    }
-}
-
-/// Finds the first EDID Discovered Protocol instance and returns the EDID data attached to it.
-pub fn find_edid() -> Option<impl Deref<Target = [u8]>> {
-    open_protocol_exclusive::<EdidDiscoveredProtocol>()
-        .ok()
-        .map(EdidRef)
-}
-
-/// Finds SMBIOS tables in the UEFI configuration tables.
-pub fn find_smbios_tables() -> Option<(&'static [u8], &'static [u8])> {
-    unsafe {
-        if let Some(ptr) =
-            find_config_table::<Smbios3EntryPoint>(uefi::table::cfg::ConfigTableEntry::SMBIOS3_GUID)
-            && (*ptr).anchor_string.eq(b"_SM3_")
-        {
-            return Some((
-                core::slice::from_raw_parts(ptr as *const u8, size_of::<Smbios3EntryPoint>()),
-                core::slice::from_raw_parts(
-                    (*ptr).table_address as *const u8,
-                    (*ptr).table_maximum_size as _,
-                ),
-            ));
-        }
-        if let Some(ptr) =
-            find_config_table::<SmbiosEntryPoint>(uefi::table::cfg::ConfigTableEntry::SMBIOS_GUID)
-            && (*ptr).anchor_string.eq(b"_SM_")
-        {
-            return Some((
-                core::slice::from_raw_parts(ptr as *const u8, size_of::<SmbiosEntryPoint>()),
-                core::slice::from_raw_parts((*ptr).table_address as _, (*ptr).table_length as _),
-            ));
-        }
-    }
-    None
-}
-
 /// EFI main function, initializes global state and calls the application entry point.
 #[uefi::entry]
 fn efi_main() -> uefi::Status {
     uefi::helpers::init().unwrap();
-    mem::efi_mem_init();
+    mem::init();
 
     unsafe extern "Rust" {
         fn lace_app_main() -> Result<(), Error>;

--- a/lace-platform/src/efi/mod.rs
+++ b/lace-platform/src/efi/mod.rs
@@ -31,6 +31,7 @@ fn open_first_protocol_exclusive<T: uefi::proto::Protocol>()
 #[uefi::entry]
 fn efi_main() -> uefi::Status {
     uefi::helpers::init().unwrap();
+    crate::console::init();
     mem::init();
 
     unsafe extern "Rust" {

--- a/lace-platform/src/efi/proto/dt_fixup.rs
+++ b/lace-platform/src/efi/proto/dt_fixup.rs
@@ -3,7 +3,7 @@
 // Authors: Mate Kukri <mate.kukri@canonical.com>
 //! EFI device-tree fix-up protocol.
 
-use crate::efi::mem::{
+use crate::mem::{
     MemoryType, PageAllocation, PageAllocationConstraint, PageAllocationIface, page_count,
 };
 

--- a/lace-platform/src/efi/tpm2.rs
+++ b/lace-platform/src/efi/tpm2.rs
@@ -3,7 +3,7 @@
 // Authors: Mate Kukri <mate.kukri@canonical.com>
 //! UEFI TPM2 abstraction.
 
-pub use crate::iface::tpm2::*;
+use crate::tpm2::*;
 use crate::{Error, debugln};
 use uefi::proto::tcg::v2 as efi_tcg_v2;
 

--- a/lace-platform/src/efi/tpm2.rs
+++ b/lace-platform/src/efi/tpm2.rs
@@ -3,8 +3,8 @@
 // Authors: Mate Kukri <mate.kukri@canonical.com>
 //! UEFI TPM2 abstraction.
 
+use crate::Error;
 use crate::tpm2::*;
-use crate::{Error, debugln};
 use uefi::proto::tcg::v2 as efi_tcg_v2;
 
 /// Hashes the given data, logs the event and extends the PCR with the hash.
@@ -31,7 +31,7 @@ pub fn hash_log_extend_event(
 
         proto.hash_log_extend_event(extend_flags_to_efi(flags), data_to_hash, event)
     } else {
-        debugln!("[efi] TCG2 protocol not available, skipping measurement");
+        log::debug!("TCG2 protocol not available, skipping measurement");
         Ok(())
     }
 }

--- a/lace-platform/src/efi/tpm2.rs
+++ b/lace-platform/src/efi/tpm2.rs
@@ -16,7 +16,7 @@ pub fn hash_log_extend_event(
     event_data: &[u8],
     data_to_hash: &[u8],
 ) -> Result<(), Error> {
-    if let Ok(mut proto) = super::open_protocol_exclusive::<efi_tcg_v2::Tcg>() {
+    if let Ok(mut proto) = super::open_first_protocol_exclusive::<efi_tcg_v2::Tcg>() {
         // Prepare buffer for event
         // Unfortunately the exact size of PcrEventInputs header is not exposed,
         // so we allocate a bit more than needed.

--- a/lace-platform/src/fs/ext4.rs
+++ b/lace-platform/src/fs/ext4.rs
@@ -16,7 +16,7 @@ pub struct Ext4Filesystem {
 impl Ext4Filesystem {
     /// Try to create a new ext4 filesystem from a block device.
     pub fn new(block_dev: Box<dyn crate::fs::base::BlockDevice>) -> Result<Self, FsError> {
-        crate::debugln!("[FS] Loading ext4 filesystem from block device");
+        log::debug!("[FS] Loading ext4 filesystem from block device");
 
         struct Adapter {
             dev: Box<dyn crate::fs::base::BlockDevice>,
@@ -37,11 +37,11 @@ impl Ext4Filesystem {
 
         let adapter = Adapter { dev: block_dev };
         let fs = ext4_view::Ext4::load(Box::new(adapter)).map_err(|e| {
-            crate::debugln!("[FS] Failed to load ext4 filesystem: {:?}", e);
+            log::debug!("[FS] Failed to load ext4 filesystem: {:?}", e);
             FsError::Invalid
         })?;
 
-        crate::debugln!("[FS] Successfully loaded ext4 filesystem");
+        log::debug!("[FS] Successfully loaded ext4 filesystem");
         Ok(Self { fs })
     }
 }
@@ -53,16 +53,16 @@ impl Filesystem for Ext4Filesystem {
             path
         } else {
             // ext4-view requires absolute paths
-            crate::debugln!(
+            log::debug!(
                 "[FS] ext4: open_file failed - path is not absolute: {}",
                 path
             );
             return Err(FsError::NotFound);
         };
 
-        crate::debugln!("[FS] ext4: opening file: {}", full_path);
+        log::debug!("[FS] ext4: opening file: {}", full_path);
         let file = self.fs.open(full_path).map_err(|e| {
-            crate::debugln!("[FS] ext4: failed to open {}: {:?}", full_path, e);
+            log::debug!("[FS] ext4: failed to open {}: {:?}", full_path, e);
             match e {
                 ext4_view::Ext4Error::NotFound => FsError::NotFound,
                 ext4_view::Ext4Error::IsADirectory => FsError::NotDirectory,
@@ -70,7 +70,7 @@ impl Filesystem for Ext4Filesystem {
             }
         })?;
 
-        crate::debugln!("[FS] ext4: successfully opened file: {}", full_path);
+        log::debug!("[FS] ext4: successfully opened file: {}", full_path);
         Ok(Box::new(Ext4File { file }))
     }
 
@@ -78,12 +78,12 @@ impl Filesystem for Ext4Filesystem {
         let full_path = if path.starts_with('/') {
             path
         } else {
-            crate::debugln!("[FS] ext4: file_exists - path not absolute: {}", path);
+            log::debug!("[FS] ext4: file_exists - path not absolute: {}", path);
             return false;
         };
 
         let exists = self.fs.exists(full_path).unwrap_or(false);
-        crate::debugln!("[FS] ext4: file_exists({}) = {}", full_path, exists);
+        log::debug!("[FS] ext4: file_exists({}) = {}", full_path, exists);
         exists
     }
 
@@ -131,7 +131,7 @@ impl File for Ext4File {
     }
 
     fn read_to_end(&mut self) -> Result<Vec<u8>, FsError> {
-        crate::debugln!("[FS] ext4: read_to_end called");
+        log::debug!("[FS] ext4: read_to_end called");
         let metadata = self.file.metadata();
         let size = metadata.len() as usize;
         let mut buf = vec![0u8; size];
@@ -149,7 +149,7 @@ impl File for Ext4File {
         }
 
         buf.truncate(total_read);
-        crate::debugln!("[FS] ext4: read_to_end read {} bytes", total_read);
+        log::debug!("[FS] ext4: read_to_end read {} bytes", total_read);
         Ok(buf)
     }
 

--- a/lace-platform/src/fs/probe.rs
+++ b/lace-platform/src/fs/probe.rs
@@ -163,7 +163,7 @@ fn probe_disk(dev: Box<dyn BlockDevice>) -> Vec<Box<dyn Filesystem>> {
     let mut results = Vec::new();
 
     if let Some((scheme, partitions)) = found {
-        crate::debugln!("[fs] Found {} with {} partitions", scheme, partitions.len());
+        log::debug!("[fs] Found {} with {} partitions", scheme, partitions.len());
         for part in &partitions {
             let part_dev = Box::new(PartitionBlockDevice {
                 inner: Rc::clone(&shared),
@@ -205,7 +205,7 @@ fn process(discovered: DiscoveredStorage) -> Vec<Box<dyn Filesystem>> {
         }
     }
 
-    crate::debugln!("[fs] Probed {} filesystems total", results.len());
+    log::debug!("[fs] Probed {} filesystems total", results.len());
     results
 }
 

--- a/lace-platform/src/hwid.rs
+++ b/lace-platform/src/hwid.rs
@@ -24,17 +24,17 @@ pub fn platform_compatible_using_hwids(hwids: &[u8]) -> Option<&str> {
         lace_util::chid_mapping::ChidMappingIterator::from(hwids)
             .collect::<Result<_, _>>()
             .ok()?;
-    debugln!("Parsed {} CHID mappings", mappings.len());
+    log::debug!("Parsed {} CHID mappings", mappings.len());
 
     // Get CHID sources
     let sources = chid_sources()?;
     for (idx, src) in sources.iter().enumerate() {
-        debugln!("CHID Source {}: {:?}", idx, src);
+        log::debug!("CHID Source {}: {:?}", idx, src);
     }
 
     // Compute CHIDs
     for (idx, chid_type) in lace_util::chid::CHID_TYPES.iter().enumerate() {
-        debugln!(
+        log::debug!(
             "CHID type {}: {:?}",
             idx,
             lace_util::chid::compute_chid(&sources, *chid_type)

--- a/lace-platform/src/hwid.rs
+++ b/lace-platform/src/hwid.rs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+// Copyright (C) 2026, Canonical Ltd.
+// Authors: Mate Kukri <mate.kukri@canonical.com>
+//! lace-platform hardware identification interfaces
+
+use alloc::vec::Vec;
+use lace_util::fdt::node::FdtNode;
+
+/// Determine platform compatibility using firmware-provided device tree.
+/// # Safety
+/// This function is unsafe because the compatible string references the firmware DTB,
+/// which may be invalidated by other code replacing it.
+pub unsafe fn platform_compatible_using_firmware_dtb() -> Option<&'static str> {
+    let dtb = unsafe { find_dtb() }?;
+    dtb.find_node("/")
+        .and_then(FdtNode::compatible)
+        .and_then(|compatible| compatible.all().next())
+}
+
+/// Determine platform compatibility using CHID mappings and sources.
+pub fn platform_compatible_using_hwids(hwids: &[u8]) -> Option<&str> {
+    // Parse CHID mappings from hwids section
+    let mappings: Vec<lace_util::chid_mapping::ChidMapping> =
+        lace_util::chid_mapping::ChidMappingIterator::from(hwids)
+            .collect::<Result<_, _>>()
+            .ok()?;
+    debugln!("Parsed {} CHID mappings", mappings.len());
+
+    // Get CHID sources
+    let sources = chid_sources()?;
+    for (idx, src) in sources.iter().enumerate() {
+        debugln!("CHID Source {}: {:?}", idx, src);
+    }
+
+    // Compute CHIDs
+    for (idx, chid_type) in lace_util::chid::CHID_TYPES.iter().enumerate() {
+        debugln!(
+            "CHID type {}: {:?}",
+            idx,
+            lace_util::chid::compute_chid(&sources, *chid_type)
+        );
+    }
+
+    // Match mappings
+    for mapping in lace_util::chid_matcher::ChidMatcher::new(&mappings, &sources) {
+        if let lace_util::chid_mapping::ChidMapping::DeviceTree {
+            compatible: Some(compatible),
+            ..
+        } = &mapping
+        {
+            return Some(compatible);
+        }
+    }
+    None
+}
+
+/// Get CHID sources from SMBIOS and EDID tables provided by the platform.
+pub fn chid_sources() -> Option<lace_util::chid::ChidSources> {
+    let (ep, table) = find_smbios_tables()?;
+    let edid = find_edid();
+    lace_util::chid::chid_sources_from_smbios_and_edid(Some(ep), table, edid.as_deref()).ok()
+}
+
+// Re-export platform specific implementations
+pub use crate::p::hwid::{find_dtb, find_edid, find_smbios_tables, install_dtb};

--- a/lace-platform/src/iface/mod.rs
+++ b/lace-platform/src/iface/mod.rs
@@ -1,7 +1,0 @@
-// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
-// Copyright (C) 2025, Canonical Ltd.
-// Authors: Mate Kukri <mate.kukri@canonical.com>
-//! Interfaces module.
-
-pub mod mem;
-pub mod tpm2;

--- a/lace-platform/src/lib.rs
+++ b/lace-platform/src/lib.rs
@@ -7,9 +7,6 @@
 
 extern crate alloc;
 
-use alloc::vec::Vec;
-use lace_util::fdt::node::FdtNode;
-
 // Portable platform interface modules. Each defines the cross-platform
 // types and re-exports the active platform's concrete implementation.
 pub mod mem;
@@ -95,71 +92,11 @@ pub use p::console;
 // Re-export derive macros
 pub use lace_util_derive::entry;
 
-pub use p::find_edid;
-pub use p::find_smbios_tables;
-
-pub mod dtb {
-    pub use super::p::dtb::{find_dtb, install_dtb};
-}
+pub mod hwid;
 
 // Unified filesystem module re-exporting common types and platform-specific functions
 pub mod fs;
 
 pub mod linux {
     pub use super::p::linux::{BootLinuxError, boot_linux};
-}
-
-/// Determine platform compatibility using firmware-provided device tree.
-/// # Safety
-/// This function is unsafe because the compatible string references the firmware DTB,
-/// which may be invalidated by other code replacing it.
-pub unsafe fn platform_compatible_using_firmware_dtb() -> Option<&'static str> {
-    let dtb = unsafe { dtb::find_dtb() }?;
-    dtb.find_node("/")
-        .and_then(FdtNode::compatible)
-        .and_then(|compatible| compatible.all().next())
-}
-
-/// Determine platform compatibility using CHID mappings and sources.
-pub fn platform_compatible_using_hwids(hwids: &[u8]) -> Option<&str> {
-    // Parse CHID mappings from hwids section
-    let mappings: Vec<lace_util::chid_mapping::ChidMapping> =
-        lace_util::chid_mapping::ChidMappingIterator::from(hwids)
-            .collect::<Result<_, _>>()
-            .ok()?;
-    debugln!("Parsed {} CHID mappings", mappings.len());
-
-    // Get CHID sources
-    let sources = chid_sources()?;
-    for (idx, src) in sources.iter().enumerate() {
-        debugln!("CHID Source {}: {:?}", idx, src);
-    }
-
-    // Compute CHIDs
-    for (idx, chid_type) in lace_util::chid::CHID_TYPES.iter().enumerate() {
-        debugln!(
-            "CHID type {}: {:?}",
-            idx,
-            lace_util::chid::compute_chid(&sources, *chid_type)
-        );
-    }
-
-    // Match mappings
-    for mapping in lace_util::chid_matcher::ChidMatcher::new(&mappings, &sources) {
-        if let lace_util::chid_mapping::ChidMapping::DeviceTree {
-            compatible: Some(compatible),
-            ..
-        } = &mapping
-        {
-            return Some(compatible);
-        }
-    }
-    None
-}
-
-/// Get CHID sources from SMBIOS and EDID tables provided by the platform.
-pub fn chid_sources() -> Option<lace_util::chid::ChidSources> {
-    let (ep, table) = find_smbios_tables()?;
-    let edid = find_edid();
-    lace_util::chid::chid_sources_from_smbios_and_edid(Some(ep), table, edid.as_deref()).ok()
 }

--- a/lace-platform/src/lib.rs
+++ b/lace-platform/src/lib.rs
@@ -7,11 +7,6 @@
 
 extern crate alloc;
 
-// Portable platform interface modules. Each defines the cross-platform
-// types and re-exports the active platform's concrete implementation.
-pub mod mem;
-pub mod tpm2;
-
 // Architecture-specific modules
 #[cfg(target_arch = "x86_64")]
 pub mod amd64;
@@ -31,36 +26,35 @@ use efi as p;
 #[cfg(feature = "mock")]
 use mock as p;
 
-// Re-export portable APIs from the active platform at the top-level namespace.
-// The list of APIs exported here constitutes the portable Lace platform API.
+// Re-export platform error type
 pub use p::Error;
+
+// Re-export entry point macro
+pub use lace_util_derive::entry;
 
 // Macros for text output that should always be available
 #[macro_export]
 macro_rules! print {
-    () => {};
-    ($($arg:tt)*) => {
-        $crate::console::print_impl(format_args!($($arg)*))
-    };
+    ($($arg:tt)*) => {{
+        use core::fmt::Write as _;
+        write!($crate::console::stdout(), $($arg)*).unwrap()
+    }};
 }
 
 #[macro_export]
 macro_rules! println {
-    () => {
-        $crate::console::println_impl(format_args!(""))
-    };
-    ($($arg:tt)*) => {
-        $crate::console::println_impl(format_args!($($arg)*))
-    };
+    ($($arg:tt)*) => {{
+        use core::fmt::Write as _;
+        writeln!($crate::console::stdout(), $($arg)*).unwrap()
+    }};
 }
 
 // Macros for debug text output that is only active in debug builds
 #[macro_export]
 #[cfg(debug_assertions)]
 macro_rules! debug {
-    () => {};
     ($($arg:tt)*) => {
-        $crate::console::print_impl(format_args!($($arg)*))
+        $crate::print!($($arg)*)
     };
 }
 
@@ -73,11 +67,8 @@ macro_rules! debug {
 #[macro_export]
 #[cfg(debug_assertions)]
 macro_rules! debugln {
-    () => {
-        $crate::console::println_impl(format_args!(""))
-    };
     ($($arg:tt)*) => {
-        $crate::console::println_impl(format_args!($($arg)*))
+        $crate::println!($($arg)*)
     };
 }
 
@@ -87,14 +78,9 @@ macro_rules! debugln {
     ($($arg:tt)*) => {};
 }
 
-pub use p::console;
-
-// Re-export derive macros
-pub use lace_util_derive::entry;
-
-pub mod hwid;
-
-// Unified filesystem module re-exporting common types and platform-specific functions
+pub mod console;
 pub mod fs;
-
+pub mod hwid;
 pub mod linux;
+pub mod mem;
+pub mod tpm2;

--- a/lace-platform/src/lib.rs
+++ b/lace-platform/src/lib.rs
@@ -97,6 +97,4 @@ pub mod hwid;
 // Unified filesystem module re-exporting common types and platform-specific functions
 pub mod fs;
 
-pub mod linux {
-    pub use super::p::linux::{BootLinuxError, boot_linux};
-}
+pub mod linux;

--- a/lace-platform/src/lib.rs
+++ b/lace-platform/src/lib.rs
@@ -32,52 +32,6 @@ pub use p::Error;
 // Re-export entry point macro
 pub use lace_util_derive::entry;
 
-// Macros for text output that should always be available
-#[macro_export]
-macro_rules! print {
-    ($($arg:tt)*) => {{
-        use core::fmt::Write as _;
-        write!($crate::console::stdout(), $($arg)*).unwrap()
-    }};
-}
-
-#[macro_export]
-macro_rules! println {
-    ($($arg:tt)*) => {{
-        use core::fmt::Write as _;
-        writeln!($crate::console::stdout(), $($arg)*).unwrap()
-    }};
-}
-
-// Macros for debug text output that is only active in debug builds
-#[macro_export]
-#[cfg(debug_assertions)]
-macro_rules! debug {
-    ($($arg:tt)*) => {
-        $crate::print!($($arg)*)
-    };
-}
-
-#[macro_export]
-#[cfg(not(debug_assertions))]
-macro_rules! debug {
-    ($($arg:tt)*) => {};
-}
-
-#[macro_export]
-#[cfg(debug_assertions)]
-macro_rules! debugln {
-    ($($arg:tt)*) => {
-        $crate::println!($($arg)*)
-    };
-}
-
-#[macro_export]
-#[cfg(not(debug_assertions))]
-macro_rules! debugln {
-    ($($arg:tt)*) => {};
-}
-
 pub mod console;
 pub mod fs;
 pub mod hwid;

--- a/lace-platform/src/lib.rs
+++ b/lace-platform/src/lib.rs
@@ -10,10 +10,10 @@ extern crate alloc;
 use alloc::vec::Vec;
 use lace_util::fdt::node::FdtNode;
 
-// Interfaces for platform implementations.
-// These are not strictly necessary as the active platform is chosen at compile time,
-// but they help to clarify the expected API surface for each platform.
-pub mod iface;
+// Portable platform interface modules. Each defines the cross-platform
+// types and re-exports the active platform's concrete implementation.
+pub mod mem;
+pub mod tpm2;
 
 // Architecture-specific modules
 #[cfg(target_arch = "x86_64")]
@@ -108,8 +108,6 @@ pub mod fs;
 pub mod linux {
     pub use super::p::linux::{BootLinuxError, boot_linux};
 }
-
-pub use p::tpm2;
 
 /// Determine platform compatibility using firmware-provided device tree.
 /// # Safety

--- a/lace-platform/src/linux.rs
+++ b/lace-platform/src/linux.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+// Copyright (C) 2025, Canonical Ltd.
+// Authors: Mate Kukri <mate.kukri@canonical.com>
+//! lace-platform Linux kernel loader interfaces
+
+// Re-export platform specific implementations
+pub use crate::p::linux::{BootLinuxError, boot_linux};

--- a/lace-platform/src/mem.rs
+++ b/lace-platform/src/mem.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
 // Copyright (C) 2025, Canonical Ltd.
 // Authors: Mate Kukri <mate.kukri@canonical.com>
-//! Memory management interfaces.
 
 use core::{mem::MaybeUninit, ptr::NonNull};
 
@@ -138,3 +137,12 @@ bitflags::bitflags! {
         const EXECUTE_PROTECT = 0x4;
     }
 }
+
+/// Computes the number of pages required to hold a given size in bytes,
+/// rounding up to the nearest page.
+pub const fn page_count(size: usize) -> usize {
+    size.div_ceil(PAGE_SIZE)
+}
+
+// Re-export platform specific implementations
+pub use crate::p::mem::{MemoryType, PAGE_SIZE, PageAllocation, change_mem_attrs, nx_required};

--- a/lace-platform/src/mock/console.rs
+++ b/lace-platform/src/mock/console.rs
@@ -3,25 +3,50 @@
 // Authors: Mate Kukri <mate.kukri@canonical.com>
 //! Mock console abstraction.
 
-extern crate std;
+use crate::console::{Input, InputEvent, Output};
 
-use crate::Error;
-use core::fmt;
-
-pub fn print_impl(args: fmt::Arguments<'_>) {
-    std::print!("{}", args);
+pub struct OutputImpl {
+    _private: (),
 }
 
-pub fn println_impl(args: fmt::Arguments<'_>) {
-    std::println!("{}", args);
+impl OutputImpl {
+    #[allow(clippy::new_without_default)]
+    pub const fn new() -> Self {
+        Self { _private: () }
+    }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub struct KeyEvent {
-    pub char: char,
-    pub scancode: u8,
+impl core::fmt::Write for OutputImpl {
+    fn write_str(&mut self, s: &str) -> Result<(), core::fmt::Error> {
+        std::io::Write::write_all(&mut std::io::stdout(), s.as_bytes())
+            .map_err(|_| core::fmt::Error)?;
+        Ok(())
+    }
 }
 
-pub fn read_key() -> Result<KeyEvent, Error> {
-    todo!()
+impl Output for OutputImpl {
+    fn get_position(&mut self) -> Result<(usize, usize), crate::Error> {
+        Ok((0, 0))
+    }
+
+    fn set_position(&mut self, _x: usize, _y: usize) -> Result<(), crate::Error> {
+        Ok(())
+    }
+}
+
+pub struct InputImpl {
+    _private: (),
+}
+
+impl InputImpl {
+    #[allow(clippy::new_without_default)]
+    pub const fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+impl Input for InputImpl {
+    fn wait_input(&mut self) -> Result<InputEvent, crate::Error> {
+        Err(crate::Error)
+    }
 }

--- a/lace-platform/src/mock/console.rs
+++ b/lace-platform/src/mock/console.rs
@@ -4,6 +4,7 @@
 //! Mock console abstraction.
 
 use crate::console::{Input, InputEvent, Output};
+use core::fmt::Write;
 
 pub struct OutputImpl {
     _private: (),
@@ -31,6 +32,11 @@ impl Output for OutputImpl {
 
     fn set_position(&mut self, _x: usize, _y: usize) -> Result<(), crate::Error> {
         Ok(())
+    }
+
+    fn clear_screen(&mut self) -> Result<(), crate::Error> {
+        // ANSI: clear screen + move cursor to home.
+        self.write_str("\x1b[2J\x1b[H").map_err(|_| crate::Error)
     }
 }
 

--- a/lace-platform/src/mock/hwid.rs
+++ b/lace-platform/src/mock/hwid.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+// Copyright (C) 2026, Canonical Ltd.
+// Authors: Mate Kukri <mate.kukri@canonical.com>
+//! Mock hardware identification
+
+pub fn find_edid() -> Option<impl std::ops::Deref<Target = [u8]>> {
+    None::<&[u8]>
+}
+
+pub fn find_smbios_tables() -> Option<(&'static [u8], &'static [u8])> {
+    None
+}
+
+/// Finds an installed DTB in the system.
+/// # Safety
+/// This is not implemented for now.
+pub unsafe fn find_dtb() -> Option<lace_util::fdt::Fdt<'static>> {
+    None
+}
+
+/// Placeholder for a DTB installation receipt.
+pub struct MockDtbReceipt;
+
+/// Installs a DTB in the system.
+/// # Safety
+/// This is not implemented for now.
+pub unsafe fn install_dtb(_dtb: &[u8]) -> Result<MockDtbReceipt, super::Error> {
+    Err(super::Error)
+}

--- a/lace-platform/src/mock/linux.rs
+++ b/lace-platform/src/mock/linux.rs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+// Copyright (C) 2026, Canonical Ltd.
+// Authors: Mate Kukri <mate.kukri@canonical.com>
+//! Mock placeholder for a Linux kernel loader.
+
+#[derive(Debug, lace_util::Display)]
+#[display("mock platform boot linux error")]
+pub struct BootLinuxError;
+
+pub fn boot_linux(
+    _kernel: &[u8],
+    _initrd: Option<&[u8]>,
+    _cmdline: Option<&str>,
+) -> Result<(), BootLinuxError> {
+    Err(BootLinuxError)
+}

--- a/lace-platform/src/mock/mem.rs
+++ b/lace-platform/src/mock/mem.rs
@@ -6,7 +6,7 @@
 use lace_util::Display;
 use spin::Mutex;
 
-use crate::iface::mem::{MemAttributes, PageAllocationConstraint, PageAllocationIface};
+use crate::mem::{MemAttributes, PageAllocationConstraint, PageAllocationIface};
 use core::ptr::NonNull;
 
 /// Address type for the sandbox platform.
@@ -15,11 +15,8 @@ pub type Address = usize;
 /// Page size for the sandbox platform. (This is an arbitrary choice.)
 pub const PAGE_SIZE: usize = 4096;
 
-/// Computes the number of pages required to hold a given size in bytes,
-/// rounding up to the nearest page.
-pub const fn page_count(size: usize) -> usize {
-    size.div_ceil(PAGE_SIZE)
-}
+/// Mock platform does not distinguish memory types
+pub struct MemoryType;
 
 /// Default alignment when none is specified (page-aligned).
 const DEFAULT_ALIGNMENT: usize = PAGE_SIZE;

--- a/lace-platform/src/mock/mod.rs
+++ b/lace-platform/src/mock/mod.rs
@@ -6,6 +6,7 @@
 pub mod console;
 pub mod fs;
 pub mod hwid;
+pub mod linux;
 pub mod mem;
 pub mod tpm2;
 
@@ -16,19 +17,3 @@ use lace_util::Display;
 pub struct Error;
 
 impl std::error::Error for Error {}
-
-pub mod linux {
-    use lace_util::Display;
-
-    #[derive(Debug, Display)]
-    #[display("mock platform boot linux error")]
-    pub struct BootLinuxError;
-
-    pub fn boot_linux(
-        _kernel: &[u8],
-        _initrd: Option<&[u8]>,
-        _cmdline: Option<&str>,
-    ) -> Result<(), BootLinuxError> {
-        todo!()
-    }
-}

--- a/lace-platform/src/mock/mod.rs
+++ b/lace-platform/src/mock/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
 // Copyright (C) 2025, Canonical Ltd.
 // Authors: Mate Kukri <mate.kukri@canonical.com>
-//! Sandbox platform abstractions.
+//! Mock platform abstractions.
 
 pub mod console;
 pub mod fs;
@@ -10,10 +10,13 @@ pub mod linux;
 pub mod mem;
 pub mod tpm2;
 
-use lace_util::Display;
-
-#[derive(Debug, Display)]
+#[derive(Debug, lace_util::Display)]
 #[display("mock platform error")]
 pub struct Error;
 
 impl std::error::Error for Error {}
+
+/// Shared mock-side initialization, invoked from `#[lace_platform::entry]`.
+pub fn init() {
+    crate::console::init();
+}

--- a/lace-platform/src/mock/mod.rs
+++ b/lace-platform/src/mock/mod.rs
@@ -4,6 +4,8 @@
 //! Sandbox platform abstractions.
 
 pub mod console;
+pub mod fs;
+pub mod hwid;
 pub mod mem;
 pub mod tpm2;
 
@@ -14,47 +16,6 @@ use lace_util::Display;
 pub struct Error;
 
 impl std::error::Error for Error {}
-
-struct EdidRef;
-
-impl std::ops::Deref for EdidRef {
-    type Target = [u8];
-
-    fn deref(&self) -> &Self::Target {
-        todo!()
-    }
-}
-
-pub fn find_edid() -> Option<impl std::ops::Deref<Target = [u8]>> {
-    Option::<EdidRef>::None
-}
-
-pub fn find_smbios_tables() -> Option<(&'static [u8], &'static [u8])> {
-    todo!()
-}
-
-pub mod dtb {
-    use lace_util::fdt::Fdt;
-
-    /// Finds an installed DTB in the system.
-    /// # Safety
-    /// This is not implemented for now.
-    pub unsafe fn find_dtb() -> Option<Fdt<'static>> {
-        todo!()
-    }
-
-    /// Placeholder for a DTB installation receipt.
-    pub struct MockDtbReceipt;
-
-    /// Installs a DTB in the system.
-    /// # Safety
-    /// This is not implemented for now.
-    pub unsafe fn install_dtb(_dtb: &[u8]) -> Result<MockDtbReceipt, super::Error> {
-        todo!()
-    }
-}
-
-pub mod fs;
 
 pub mod linux {
     use lace_util::Display;

--- a/lace-platform/src/mock/tpm2.rs
+++ b/lace-platform/src/mock/tpm2.rs
@@ -4,7 +4,7 @@
 //! Mock TPM2 abstraction.
 
 use crate::Error;
-pub use crate::iface::tpm2::*;
+use crate::tpm2::*;
 
 pub fn hash_log_extend_event(
     _pcr_index: u32,
@@ -13,5 +13,5 @@ pub fn hash_log_extend_event(
     _event_data: &[u8],
     _data_to_hash: &[u8],
 ) -> Result<(), Error> {
-    todo!()
+    Err(Error)
 }

--- a/lace-platform/src/tpm2.rs
+++ b/lace-platform/src/tpm2.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
 // Copyright (C) 2026, Canonical Ltd.
 // Authors: Mate Kukri <mate.kukri@canonical.com>
-//! TPM2 interface module.
 
 use bitflags::bitflags;
 
@@ -73,3 +72,6 @@ impl EventType {
         self as u32
     }
 }
+
+// Re-export platform specific implementations
+pub use crate::p::tpm2::hash_log_extend_event;

--- a/lace-speedboot/Cargo.toml
+++ b/lace-speedboot/Cargo.toml
@@ -8,6 +8,7 @@ license = "GPL-2.0-only OR GPL-3.0-only"
 lace-util = { version = "0.1.0", path = "../lace-util", default-features = false, features = ["grub"] }
 lace-platform = { version = "0.1.0", path = "../lace-platform", default-features = false, features = ["ext4"] }
 lace-stubble = { version = "0.1.0", path = "../lace-stubble", default-features = false }
+log.workspace = true
 
 [features]
 default = ["mock"]

--- a/lace-speedboot/src/bootflows/bls.rs
+++ b/lace-speedboot/src/bootflows/bls.rs
@@ -9,7 +9,7 @@ use alloc::rc::Rc;
 use alloc::string::ToString;
 use alloc::vec::Vec;
 use core::cell::RefCell;
-use lace_platform::{fs::Filesystem, println};
+use lace_platform::fs::Filesystem;
 use lace_util::bls::parse_bls_entry;
 
 use super::{BootConfiguration, BootFlow, SimpleBootConfiguration};
@@ -57,7 +57,7 @@ impl BootFlow for BlsBootFlow {
                 Err(_) => continue, // Directory doesn't exist, try next
             };
 
-            println!("  Found BLS directory: {}", bls_dir);
+            log::debug!("Found BLS directory: {}", bls_dir);
 
             // Process each .conf file in the directory
             for entry in entries {
@@ -75,11 +75,7 @@ impl BootFlow for BlsBootFlow {
                         {
                             let bls_entry = parse_bls_entry(content);
 
-                            println!(
-                                "    Found BLS entry: {} ({})",
-                                bls_entry.title(),
-                                entry.name
-                            );
+                            log::debug!("Found BLS entry: {} ({})", bls_entry.title(), entry.name);
 
                             // Create boot configuration
                             all_configs.push(Box::new(SimpleBootConfiguration::new(

--- a/lace-speedboot/src/bootflows/grub.rs
+++ b/lace-speedboot/src/bootflows/grub.rs
@@ -10,7 +10,6 @@ use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::cell::RefCell;
 use lace_platform::fs::{Filesystem, FsError};
-use lace_platform::println;
 use lace_util::grub::{MenuEntry, parse_grub_cfg};
 
 use super::{BootConfiguration, BootFlow, SimpleBootConfiguration};
@@ -116,13 +115,13 @@ impl BootFlow for GrubBootFlow {
         for grub_path in GRUB_PATHS {
             let path = ensure_leading_slash(grub_path);
             if let Ok(mut file) = filesystem.borrow_mut().open_file(&path) {
-                println!("  Found: {}", grub_path);
+                log::debug!("Found GRUB config: {}", grub_path);
 
                 if let Ok(content_bytes) = file.read_to_end()
                     && let Ok(content) = core::str::from_utf8(&content_bytes)
                 {
                     let entries = parse_grub_cfg(content);
-                    println!("    Parsed {} menu entries", entries.len());
+                    log::debug!("Parsed {} menu entries", entries.len());
                     all_configs.append(
                         &mut self.build_boot_configurations(&entries, Rc::clone(&filesystem)),
                     );

--- a/lace-speedboot/src/bootflows/mod.rs
+++ b/lace-speedboot/src/bootflows/mod.rs
@@ -14,7 +14,6 @@ use alloc::vec::Vec;
 use core::cell::RefCell;
 use lace_platform::fs::Filesystem;
 use lace_platform::linux::boot_linux;
-use lace_platform::println;
 
 /// Trait for boot configurations.
 pub trait BootConfiguration {
@@ -61,16 +60,15 @@ impl BootConfiguration for SimpleBootConfiguration {
     }
 
     fn start(self: Box<Self>) -> Result<(), SpeedbootError> {
-        println!("\nBooting: {}", self.title);
-
+        log::info!("Booting: {}", self.title);
         if let Some(ref linux_path) = self.linux {
-            println!("  Kernel: {}", linux_path);
+            log::debug!("Kernel: {}", linux_path);
         }
         if let Some(ref initrd) = self.initrd {
-            println!("  Initrd: {}", initrd);
+            log::debug!("Initrd: {}", initrd);
         }
         if let Some(ref cmdline) = self.cmdline {
-            println!("  Cmdline: {}", cmdline);
+            log::debug!("Cmdline: {}", cmdline);
         }
 
         // Load kernel and initrd from filesystem
@@ -81,7 +79,7 @@ impl BootConfiguration for SimpleBootConfiguration {
         )?;
 
         // Boot Linux
-        println!("  Starting kernel...");
+        log::debug!("Starting kernel");
 
         match lace_stubble::boot_stubble_image(
             lace_stubble::StubbleImage::Raw(&kernel_data),
@@ -117,8 +115,8 @@ pub fn discover_all() -> Result<Vec<Box<dyn BootConfiguration>>, SpeedbootError>
 
     let mut all_configs = Vec::new();
 
-    println!(
-        "Scanning {} filesystems for boot configurations...",
+    log::debug!(
+        "Scanning {} filesystems for boot configurations",
         filesystems.len()
     );
 
@@ -142,7 +140,7 @@ pub fn discover_all() -> Result<Vec<Box<dyn BootConfiguration>>, SpeedbootError>
         return Err(SpeedbootError::NoBootEntriesFound);
     }
 
-    println!("Found {} boot configurations total\n", all_configs.len());
+    log::debug!("Found {} boot configurations total", all_configs.len());
 
     Ok(all_configs)
 }

--- a/lace-speedboot/src/main.rs
+++ b/lace-speedboot/src/main.rs
@@ -15,11 +15,13 @@ mod text;
 extern crate alloc;
 
 use alloc::string::String;
+use core::fmt::Write;
 
 #[lace_platform::entry]
 fn main() -> Result<(), lace_platform::Error> {
-    lace_platform::println!("Lace Speedboot - Fast Boot Menu");
-    lace_platform::println!("================================\n");
+    let mut stdout = lace_platform::console::stdout();
+    let _ = writeln!(stdout, "Lace Speedboot - Fast Boot Menu");
+    let _ = writeln!(stdout, "================================\n");
 
     // Discover boot configurations from all boot flows
     let mut boot_configs =

--- a/lace-speedboot/src/text.rs
+++ b/lace-speedboot/src/text.rs
@@ -30,9 +30,11 @@ pub fn get_user_selection(max: usize) -> Result<usize, SpeedbootError> {
 
     // Read input character by character
     loop {
-        let key_event =
-            lace_platform::console::read_key().map_err(|_| SpeedbootError::InvalidSelection)?;
-        let c = key_event.char;
+        let input_event = lace_platform::console::Input::wait_input(
+            &mut lace_platform::console::stdin(),
+        )
+        .map_err(|_| SpeedbootError::InvalidSelection)?;
+        let c = input_event.char;
 
         if c == '\r' || c == '\n' {
             println!();

--- a/lace-speedboot/src/text.rs
+++ b/lace-speedboot/src/text.rs
@@ -5,49 +5,49 @@
 
 use alloc::boxed::Box;
 use alloc::string::String;
-use lace_platform::{print, println};
+use core::fmt::Write;
+use lace_platform::console::{Input, stdin, stdout};
 
 use crate::SpeedbootError;
 use crate::bootflows::BootConfiguration;
 
 /// Display the boot menu to the user.
 pub fn display_menu(entries: &[Box<dyn BootConfiguration>]) {
-    println!("Boot Menu:");
-    println!("-----------");
-
+    let mut stdout = stdout();
+    let _ = writeln!(stdout, "Boot Menu:");
+    let _ = writeln!(stdout, "-----------");
     for (idx, entry) in entries.iter().enumerate() {
-        println!("  [{}] {}", idx, entry.title());
+        let _ = writeln!(stdout, "  [{}] {}", idx, entry.title());
     }
-
-    println!("");
+    let _ = writeln!(stdout);
 }
 
 /// Get user selection from the menu.
 pub fn get_user_selection(max: usize) -> Result<usize, SpeedbootError> {
-    print!("Select boot entry (0-{}): ", max - 1);
+    let mut stdout = stdout();
+    let _ = write!(stdout, "Select boot entry (0-{}): ", max - 1);
 
     let mut selection_str = String::new();
 
     // Read input character by character
     loop {
-        let input_event = lace_platform::console::Input::wait_input(
-            &mut lace_platform::console::stdin(),
-        )
-        .map_err(|_| SpeedbootError::InvalidSelection)?;
+        let input_event = stdin()
+            .wait_input()
+            .map_err(|_| SpeedbootError::InvalidSelection)?;
         let c = input_event.char;
 
         if c == '\r' || c == '\n' {
-            println!();
+            let _ = writeln!(stdout);
             break;
         } else if c == '\x08' {
             // Backspace
             if !selection_str.is_empty() {
                 selection_str.pop();
-                print!("\x08 \x08");
+                let _ = write!(stdout, "\x08 \x08");
             }
         } else if c.is_ascii_digit() {
             selection_str.push(c);
-            print!("{}", c);
+            let _ = write!(stdout, "{}", c);
         }
     }
 

--- a/lace-stubble/Cargo.toml
+++ b/lace-stubble/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [dependencies]
 lace-util = { path = "../lace-util", default-features = false }
 lace-platform = { path = "../lace-platform", default-features = false }
+log.workspace = true
 uefi = { workspace = true, optional = true }
 
 [features]

--- a/lace-stubble/src/lib.rs
+++ b/lace-stubble/src/lib.rs
@@ -9,7 +9,7 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 use lace_platform::debugln;
-use lace_platform::dtb::install_dtb;
+use lace_platform::hwid::install_dtb;
 use lace_platform::linux::boot_linux;
 use lace_platform::tpm2::{self, EventType, ExtendFlags};
 use lace_util::Display;
@@ -108,10 +108,10 @@ pub fn boot_stubble_image<'image>(
 
     // First try to get platform compatible from firmware DTB
     // If that fails, try using CHID matching against .hwids section
-    let compatible =
-        unsafe { lace_platform::platform_compatible_using_firmware_dtb() }.or_else(|| {
+    let compatible = unsafe { lace_platform::hwid::platform_compatible_using_firmware_dtb() }
+        .or_else(|| {
             hwids
-                .map(|hwids| lace_platform::platform_compatible_using_hwids(hwids))
+                .map(|hwids| lace_platform::hwid::platform_compatible_using_hwids(hwids))
                 .unwrap_or(None)
         });
     debugln!(

--- a/lace-stubble/src/lib.rs
+++ b/lace-stubble/src/lib.rs
@@ -8,7 +8,6 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
-use lace_platform::debugln;
 use lace_platform::hwid::install_dtb;
 use lace_platform::linux::boot_linux;
 use lace_platform::tpm2::{self, EventType, ExtendFlags};
@@ -60,7 +59,7 @@ pub fn boot_stubble_image<'image>(
     let section_filter =
         |result: Result<(SectionHeader, &'image [u8]), PeError>| -> Result<(), BootStubbleError> {
             let (sect, data) = result.map_err(BootStubbleError::PeError)?;
-            debugln!(
+            log::debug!(
                 "  {:<8} {:08x} {:08x}",
                 str::from_utf8(sect.name()).unwrap(),
                 sect.virtual_address,
@@ -88,7 +87,7 @@ pub fn boot_stubble_image<'image>(
             Ok(())
         };
 
-    debugln!("PE sections");
+    log::debug!("PE sections");
     if raw {
         pe.raw_sections().try_for_each(section_filter)?;
     } else {
@@ -114,7 +113,7 @@ pub fn boot_stubble_image<'image>(
                 .map(|hwids| lace_platform::hwid::platform_compatible_using_hwids(hwids))
                 .unwrap_or(None)
         });
-    debugln!(
+    log::debug!(
         "Determined platform compatible: {}",
         compatible.unwrap_or("<none>")
     );
@@ -127,7 +126,7 @@ pub fn boot_stubble_image<'image>(
             let dtb_fdt = match lace_util::fdt::Fdt::new(dtb_data) {
                 Ok(fdt) => fdt,
                 Err(e) => {
-                    debugln!("Skipping invalid .dtbauto section: {}", e);
+                    log::debug!("Skipping invalid .dtbauto section: {}", e);
                     continue;
                 }
             };
@@ -136,24 +135,24 @@ pub fn boot_stubble_image<'image>(
                 .and_then(|n| n.compatible())
                 .and_then(|compatible| compatible.all().next())
             else {
-                debugln!("Skipping .dtbauto section with no compatible property");
+                log::debug!("Skipping .dtbauto section with no compatible property");
                 continue;
             };
             if dtb_compatible == compatible {
-                debugln!("Installing DTB for compatible {}", compatible);
+                log::debug!("Installing DTB for compatible {}", compatible);
                 installed_dtb =
                     unsafe { Some(install_dtb(dtb_data).expect("failed to install DTB")) };
                 break;
             }
         }
         if installed_dtb.is_none() {
-            debugln!(
+            log::debug!(
                 "No matching DTB found for compatible {}, skipping DTB installation",
                 compatible
             );
         }
     } else {
-        debugln!("No platform compatible determined, skipping DTB installation");
+        log::debug!("No platform compatible determined, skipping DTB installation");
     }
 
     // Measure kernel command line to TPM 2.0 - PCR 12
@@ -168,7 +167,7 @@ pub fn boot_stubble_image<'image>(
     ) {
         Ok(()) => (),
         Err(err) => {
-            debugln!("Failed to measure kernel command line: {}", err);
+            log::debug!("Failed to measure kernel command line: {}", err);
         }
     }
 

--- a/lace-stubble/src/main.rs
+++ b/lace-stubble/src/main.rs
@@ -35,10 +35,7 @@ fn main() -> Result<(), lace_platform::Error> {
             )
             .map(|r| {
                 r.unwrap_or_else(|err| {
-                    lace_platform::debugln!(
-                        "WARNING: command line contains invalid character: {}",
-                        err
-                    );
+                    log::warn!("command line contains invalid character: {}", err);
                     core::char::REPLACEMENT_CHARACTER
                 })
             })

--- a/lace-util/src/chid.rs
+++ b/lace-util/src/chid.rs
@@ -228,7 +228,7 @@ pub fn chid_sources_from_smbios_and_edid(
             } else {
                 return false;
             };
-            cmp_maj_min(maj, min, 2, 4).is_ge()
+            (maj, min) >= (2, 4)
         })
         .unwrap_or_else(|| false);
 

--- a/lace-util/src/lib.rs
+++ b/lace-util/src/lib.rs
@@ -20,7 +20,6 @@ pub mod smbios;
 pub mod tempfile;
 pub mod units;
 
-use core::cmp::Ordering;
 use core::fmt::{self, Debug, Write};
 use zerocopy::byteorder::{ByteOrder, U16, U32};
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
@@ -288,14 +287,6 @@ impl<O: ByteOrder> Debug for OrderedGuid<O> {
     }
 }
 
-/// Compare two version numbers in "major.minor" format.
-pub fn cmp_maj_min(maj_a: u8, min_a: u8, maj_b: u8, min_b: u8) -> Ordering {
-    match maj_a.cmp(&maj_b) {
-        Ordering::Equal => min_a.cmp(&min_b),
-        ord => ord,
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -372,31 +363,6 @@ mod test {
         let debug_str = format!("{:?}", guid);
         assert!(debug_str.contains("guid_str"));
         assert!(debug_str.contains("12345678-1234-5678-9abc-def012345678"));
-    }
-
-    #[test]
-    fn test_cmp_maj_min_greater() {
-        assert_eq!(cmp_maj_min(2, 0, 1, 9), Ordering::Greater);
-    }
-
-    #[test]
-    fn test_cmp_maj_min_less() {
-        assert_eq!(cmp_maj_min(1, 5, 2, 0), Ordering::Less);
-    }
-
-    #[test]
-    fn test_cmp_maj_min_equal_major_greater_minor() {
-        assert_eq!(cmp_maj_min(2, 5, 2, 3), Ordering::Greater);
-    }
-
-    #[test]
-    fn test_cmp_maj_min_equal_major_less_minor() {
-        assert_eq!(cmp_maj_min(2, 3, 2, 5), Ordering::Less);
-    }
-
-    #[test]
-    fn test_cmp_maj_min_equal() {
-        assert_eq!(cmp_maj_min(2, 3, 2, 3), Ordering::Equal);
     }
 
     #[test]


### PR DESCRIPTION
Flatten lace-platform so the portable interface lives at the crate root (console, mem, hwid, linux, tpm2) and each platform (bios, efi, mock) mirrors
   that shape one-to-one. The console becomes a trait-based Output/Input API with global static mutexes and a const new() per platform. Diagnostic
  output moves to the log crate, leaving with_stdout only for interactive UI. Panics route through a single console::panic that clears the screen and
  draws a framed report; bios, efi, and mock all install it. Eight commits, no behavioral change beyond the panic display.