### PR TITLE
lace-util: Introduce basic ACPI and ELF64 parsers

### DIFF
--- a/lace-util/Cargo.toml
+++ b/lace-util/Cargo.toml
@@ -11,6 +11,7 @@ libc = { workspace = true, optional = true }
 zerocopy = { workspace = true, features = ["derive"] }
 
 [features]
-default = ["std", "grub"]
+default = ["firmware", "std", "grub"]
+firmware = []
 std = ["dep:libc"]
 grub = []

--- a/lace-util/src/acpi/fadt.rs
+++ b/lace-util/src/acpi/fadt.rs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+// Copyright (C) 2026, Canonical Ltd.
+// Authors: Mate Kukri <mate.kukri@canonical.com>
+
+//! ACPI FADT (Fixed ACPI Description Table) and FACS parsing.
+
+use zerocopy::{
+    FromBytes, Immutable, KnownLayout,
+    byteorder::{LE, U16, U32, U64},
+};
+
+/// ACPI Generic Address Structure (GAS).
+#[repr(C, packed)]
+#[derive(Clone, Copy, FromBytes, Immutable, KnownLayout)]
+pub struct Gas {
+    pub address_space_id: u8,
+    pub register_bit_width: u8,
+    pub register_bit_offset: u8,
+    pub access_size: u8,
+    pub address: U64<LE>,
+}
+
+/// ACPI FADT (Fixed ACPI Description Table), revision 3+ layout.
+#[repr(C, packed)]
+#[derive(FromBytes, Immutable, KnownLayout)]
+pub struct Fadt {
+    pub header: super::SdtHeader,
+    pub firmware_ctrl: U32<LE>,
+    pub dsdt: U32<LE>,
+    pub reserved0: u8,
+    pub preferred_pm_profile: u8,
+    pub sci_int: U16<LE>,
+    pub smi_cmd: U32<LE>,
+    pub acpi_enable: u8,
+    pub acpi_disable: u8,
+    pub s4bios_req: u8,
+    pub pstate_cnt: u8,
+    pub pm1a_evt_blk: U32<LE>,
+    pub pm1b_evt_blk: U32<LE>,
+    pub pm1a_cnt_blk: U32<LE>,
+    pub pm1b_cnt_blk: U32<LE>,
+    pub pm2_cnt_blk: U32<LE>,
+    pub pm_tmr_blk: U32<LE>,
+    pub gpe0_blk: U32<LE>,
+    pub gpe1_blk: U32<LE>,
+    pub pm1_evt_len: u8,
+    pub pm1_cnt_len: u8,
+    pub pm2_cnt_len: u8,
+    pub pm_tmr_len: u8,
+    pub gpe0_blk_len: u8,
+    pub gpe1_blk_len: u8,
+    pub gpe1_base: u8,
+    pub cst_cnt: u8,
+    pub p_lvl2_lat: U16<LE>,
+    pub p_lvl3_lat: U16<LE>,
+    pub flush_size: U16<LE>,
+    pub flush_stride: U16<LE>,
+    pub duty_offset: u8,
+    pub duty_width: u8,
+    pub day_alrm: u8,
+    pub mon_alrm: u8,
+    pub century: u8,
+    pub iapc_boot_arch: U16<LE>,
+    pub reserved1: u8,
+    pub flags: U32<LE>,
+    pub reset_reg: Gas,
+    pub reset_value: u8,
+    pub reserved2: [u8; 3],
+    pub x_firmware_ctrl: U64<LE>,
+    pub x_dsdt: U64<LE>,
+    pub x_pm1a_evt_blk: Gas,
+    pub x_pm1b_evt_blk: Gas,
+    pub x_pm1a_cnt_blk: Gas,
+    pub x_pm1b_cnt_blk: Gas,
+    pub x_pm2_cnt_blk: Gas,
+    pub x_pm_tmr_blk: Gas,
+    pub x_gpe0_blk: Gas,
+    pub x_gpe1_blk: Gas,
+}
+
+/// ACPI FACS (Firmware ACPI Control Structure).
+#[repr(C, packed)]
+#[derive(FromBytes, Immutable, KnownLayout)]
+pub struct Facs {
+    pub signature: [u8; 4],
+    pub length: U32<LE>,
+    pub hardware_signature: U32<LE>,
+    pub firmware_waking_vector: U32<LE>,
+    pub global_lock: U32<LE>,
+    pub flags: U32<LE>,
+    pub x_firmware_waking_vector: U64<LE>,
+    pub version: u8,
+}
+
+/// Extract the FACS physical address from a FADT.
+pub fn parse_fadt_facs_addr(data: &[u8]) -> Option<u64> {
+    let (fadt, _) = Fadt::ref_from_prefix(data).ok()?;
+    if &fadt.header.signature != b"FACP" {
+        return None;
+    }
+
+    // Prefer 64-bit X_FIRMWARE_CTRL if non-zero
+    let addr = if fadt.x_firmware_ctrl != 0 {
+        fadt.x_firmware_ctrl.get()
+    } else {
+        fadt.firmware_ctrl.get().into()
+    };
+
+    if addr == 0 { None } else { Some(addr) }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_parse_fadt_facs_addr_32bit() {
+        let mut data = [0u8; size_of::<Fadt>()];
+        data[0..4].copy_from_slice(b"FACP");
+        data[4..8].copy_from_slice(&(size_of::<Fadt>() as u32).to_le_bytes());
+        // firmware_ctrl at offset 36
+        let facs_addr: u32 = 0xDEAD_0000;
+        data[36..40].copy_from_slice(&facs_addr.to_le_bytes());
+
+        assert_eq!(parse_fadt_facs_addr(&data), Some(0xDEAD_0000));
+    }
+
+    #[test]
+    fn test_parse_fadt_facs_addr_64bit() {
+        let mut data = [0u8; size_of::<Fadt>()];
+        data[0..4].copy_from_slice(b"FACP");
+        data[4..8].copy_from_slice(&(size_of::<Fadt>() as u32).to_le_bytes());
+        // firmware_ctrl (32-bit) at offset 36
+        data[36..40].copy_from_slice(&0x1234_0000u32.to_le_bytes());
+        // x_firmware_ctrl (64-bit)
+        let x_offset = core::mem::offset_of!(Fadt, x_firmware_ctrl);
+        data[x_offset..x_offset + 8].copy_from_slice(&0xCAFE_BABE_0000u64.to_le_bytes());
+
+        // Should prefer x_firmware_ctrl
+        assert_eq!(parse_fadt_facs_addr(&data), Some(0xCAFE_BABE_0000));
+    }
+
+    #[test]
+    fn test_parse_fadt_bad_signature() {
+        let mut data = [0u8; size_of::<Fadt>()];
+        data[0..4].copy_from_slice(b"XXXX");
+        assert_eq!(parse_fadt_facs_addr(&data), None);
+    }
+
+    #[test]
+    fn test_parse_fadt_zero_facs() {
+        let mut data = [0u8; size_of::<Fadt>()];
+        data[0..4].copy_from_slice(b"FACP");
+        data[4..8].copy_from_slice(&(size_of::<Fadt>() as u32).to_le_bytes());
+        assert_eq!(parse_fadt_facs_addr(&data), None);
+    }
+}

--- a/lace-util/src/acpi/mcfg.rs
+++ b/lace-util/src/acpi/mcfg.rs
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+// Copyright (C) 2026, Canonical Ltd.
+// Authors: Mate Kukri <mate.kukri@canonical.com>
+
+//! ACPI MCFG (Memory Mapped Configuration Space) table parser
+
+use super::SdtHeader;
+use zerocopy::{
+    FromBytes, Immutable, KnownLayout,
+    byteorder::{LE, U16, U32, U64},
+};
+
+/// MCFG allocation entry — describes one PCI segment's ECAM region.
+#[repr(C, packed)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, FromBytes, Immutable, KnownLayout)]
+pub struct McfgEntry {
+    pub base_address: U64<LE>,
+    pub segment_group: U16<LE>,
+    pub start_bus: u8,
+    pub end_bus: u8,
+    pub _reserved: U32<LE>,
+}
+
+/// Parse the MCFG table from a byte slice and return the first allocation entry.
+///
+/// The caller is responsible for producing `data` from the physical MCFG
+/// address; by taking a slice rather than a raw pointer the parsing logic is
+/// safe and unit-testable.
+pub fn parse_mcfg(data: &[u8]) -> Option<McfgEntry> {
+    let (header, _) = SdtHeader::ref_from_prefix(data).ok()?;
+    if &header.signature != b"MCFG" {
+        return None;
+    }
+
+    // 8 bytes of reserved space follow the SDT header, then the entries.
+    let entries_offset = size_of::<SdtHeader>() + 8;
+    let total_length = header.length.get().try_into().unwrap();
+    if total_length > data.len() || total_length < entries_offset + size_of::<McfgEntry>() {
+        return None;
+    }
+
+    let (entry, _) = McfgEntry::ref_from_prefix(&data[entries_offset..total_length]).ok()?;
+    Some(*entry)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn build_mcfg(entry: &McfgEntry) -> alloc::vec::Vec<u8> {
+        let sdt_hdr_size = size_of::<SdtHeader>();
+        let entries_offset = sdt_hdr_size + 8;
+        let total = entries_offset + size_of::<McfgEntry>();
+        let mut buf = alloc::vec![0u8; total];
+        buf[0..4].copy_from_slice(b"MCFG");
+        buf[4..8].copy_from_slice(&(total as u32).to_le_bytes());
+
+        let entry_bytes = &mut buf[entries_offset..total];
+        entry_bytes[0..8].copy_from_slice(&entry.base_address.get().to_le_bytes());
+        entry_bytes[8..10].copy_from_slice(&entry.segment_group.get().to_le_bytes());
+        entry_bytes[10] = entry.start_bus;
+        entry_bytes[11] = entry.end_bus;
+        buf
+    }
+
+    #[test]
+    fn test_parse_mcfg_valid() {
+        let entry = McfgEntry {
+            base_address: 0xE000_0000.into(),
+            segment_group: 0.into(),
+            start_bus: 0,
+            end_bus: 0xFF,
+            _reserved: 0.into(),
+        };
+        let buf = build_mcfg(&entry);
+        let parsed = parse_mcfg(&buf).unwrap();
+        assert_eq!({ parsed.base_address }, 0xE000_0000);
+        assert_eq!({ parsed.segment_group }, 0);
+        assert_eq!(parsed.start_bus, 0);
+        assert_eq!(parsed.end_bus, 0xFF);
+    }
+
+    #[test]
+    fn test_parse_mcfg_bad_signature() {
+        let entry = McfgEntry {
+            base_address: 0.into(),
+            segment_group: 0.into(),
+            start_bus: 0,
+            end_bus: 0,
+            _reserved: 0.into(),
+        };
+        let mut buf = build_mcfg(&entry);
+        buf[0..4].copy_from_slice(b"FACP");
+        assert!(parse_mcfg(&buf).is_none());
+    }
+
+    #[test]
+    fn test_parse_mcfg_truncated() {
+        let entry = McfgEntry {
+            base_address: 0.into(),
+            segment_group: 0.into(),
+            start_bus: 0,
+            end_bus: 0,
+            _reserved: 0.into(),
+        };
+        let buf = build_mcfg(&entry);
+        // Drop the last byte of the entry — length field still claims full size.
+        assert!(parse_mcfg(&buf[..buf.len() - 1]).is_none());
+    }
+
+    #[test]
+    fn test_parse_mcfg_no_entries() {
+        let sdt_hdr_size = size_of::<SdtHeader>();
+        let total = sdt_hdr_size + 8; // header + reserved, no entries
+        let mut buf = alloc::vec![0u8; total];
+        buf[0..4].copy_from_slice(b"MCFG");
+        buf[4..8].copy_from_slice(&(total as u32).to_le_bytes());
+        assert!(parse_mcfg(&buf).is_none());
+    }
+}

--- a/lace-util/src/acpi/mod.rs
+++ b/lace-util/src/acpi/mod.rs
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+// Copyright (C) 2026, Canonical Ltd.
+// Authors: Mate Kukri <mate.kukri@canonical.com>
+
+//! Minimal ACPI table parser
+//!
+//! Parses RSDP, XSDT/RSDT, and locates tables by signature.
+
+use zerocopy::{
+    FromBytes, Immutable, KnownLayout,
+    byteorder::{LE, U32, U64},
+};
+
+pub mod fadt;
+pub mod mcfg;
+
+/// ACPI RSDP v1 (revision 0), 20 bytes.
+#[repr(C, packed)]
+#[derive(FromBytes, Immutable, KnownLayout)]
+pub struct RsdpV1 {
+    pub signature: [u8; 8],
+    pub checksum: u8,
+    pub oem_id: [u8; 6],
+    pub revision: u8,
+    pub rsdt_address: U32<LE>,
+}
+
+/// ACPI RSDP v2 extension (revision >= 2), 36 bytes total.
+#[repr(C, packed)]
+#[derive(FromBytes, Immutable, KnownLayout)]
+pub struct RsdpV2 {
+    pub v1: RsdpV1,
+    pub length: U32<LE>,
+    pub xsdt_address: U64<LE>,
+    pub extended_checksum: u8,
+    pub _reserved: [u8; 3],
+}
+
+/// ACPI System Description Table header (common to all ACPI tables).
+#[repr(C, packed)]
+#[derive(FromBytes, Immutable, KnownLayout)]
+pub struct SdtHeader {
+    pub signature: [u8; 4],
+    pub length: U32<LE>,
+    pub revision: u8,
+    pub checksum: u8,
+    pub oem_id: [u8; 6],
+    pub oem_table_id: [u8; 8],
+    pub oem_revision: U32<LE>,
+    pub creator_id: U32<LE>,
+    pub creator_revision: U32<LE>,
+}
+
+/// Parsed RSDP — provides access to either RSDT (v1) or XSDT (v2) address.
+pub struct Rsdp {
+    pub revision: u8,
+    pub rsdt_address: u32,
+    pub xsdt_address: u64, // 0 if revision < 2
+}
+
+/// Sum of `data` as a single wrapping byte. ACPI mandates that the
+/// checksummed region sums to zero.
+fn acpi_checksum(data: &[u8]) -> u8 {
+    data.iter().fold(0u8, |acc, &b| acc.wrapping_add(b))
+}
+
+impl Rsdp {
+    /// Parse the RSDP from a byte slice.
+    pub fn parse(data: &[u8]) -> Option<Self> {
+        let (v1, _) = RsdpV1::ref_from_prefix(data).ok()?;
+        if &v1.signature != b"RSD PTR " {
+            return None;
+        }
+
+        // ACPI v1 checksum: first 20 bytes sum to zero.
+        if acpi_checksum(&data[..size_of::<RsdpV1>()]) != 0 {
+            return None;
+        }
+
+        let revision = v1.revision;
+        let rsdt_address = v1.rsdt_address.get();
+
+        let xsdt_address = if revision >= 2 {
+            let (v2, _) = RsdpV2::ref_from_prefix(data).ok()?;
+            // ACPI v2+ extended checksum: the first `length` bytes sum to zero.
+            let length = v2.length.get().try_into().unwrap();
+            if length < size_of::<RsdpV2>() || length > data.len() {
+                return None;
+            }
+            if acpi_checksum(&data[..length]) != 0 {
+                return None;
+            }
+            v2.xsdt_address.get()
+        } else {
+            0
+        };
+
+        Some(Self {
+            revision,
+            rsdt_address,
+            xsdt_address,
+        })
+    }
+
+    /// Find a table by signature in the XSDT or RSDT.
+    ///
+    /// `deref` resolves a physical address and length to a byte slice.
+    /// This is the only part that requires unsafe on bare metal (the caller
+    /// provides it), keeping the search logic itself safe and testable.
+    pub fn find_table<'a>(
+        &self,
+        signature: &[u8; 4],
+        deref: impl Fn(u64, usize) -> &'a [u8],
+    ) -> Option<u64> {
+        let (sdt_addr, ptr_size) = if self.revision >= 2 && self.xsdt_address != 0 {
+            (self.xsdt_address, 8)
+        } else {
+            (self.rsdt_address.into(), 4)
+        };
+
+        // Read the SDT header to get the total length
+        let header_bytes = deref(sdt_addr, size_of::<SdtHeader>());
+        let (header, _) = SdtHeader::ref_from_prefix(header_bytes).ok()?;
+        let total_length = header.length.get().try_into().unwrap();
+
+        // Read the full SDT
+        let sdt_data = deref(sdt_addr, total_length);
+
+        // Walk entries
+        let entries_offset = size_of::<SdtHeader>();
+        let entries_len = total_length.checked_sub(entries_offset)?;
+        let num_entries = entries_len / ptr_size;
+
+        for i in 0..num_entries {
+            let off = entries_offset + i * ptr_size;
+            if off + ptr_size > sdt_data.len() {
+                break;
+            }
+            let addr = if ptr_size == 8 {
+                u64::from_le_bytes(sdt_data[off..off + 8].try_into().ok()?)
+            } else {
+                u32::from_le_bytes(sdt_data[off..off + 4].try_into().ok()?).into()
+            };
+
+            // Read the table's signature
+            let table_header = deref(addr, 4);
+            if table_header == signature {
+                return Some(addr);
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Write an ACPI-style checksum byte at `data[checksum_index]` so the
+    /// covered region sums to zero.
+    fn fix_checksum(data: &mut [u8], checksum_index: usize, length: usize) {
+        data[checksum_index] = 0;
+        let sum = acpi_checksum(&data[..length]);
+        data[checksum_index] = 0u8.wrapping_sub(sum);
+    }
+
+    #[test]
+    fn test_parse_rsdp_v1() {
+        let mut data = [0u8; 20];
+        data[0..8].copy_from_slice(b"RSD PTR ");
+        data[15] = 0; // revision 0
+        data[16..20].copy_from_slice(&0x12345678u32.to_le_bytes());
+        fix_checksum(&mut data, 8, 20);
+
+        let rsdp = Rsdp::parse(&data).unwrap();
+        assert_eq!(rsdp.revision, 0);
+        assert_eq!(rsdp.rsdt_address, 0x12345678);
+        assert_eq!(rsdp.xsdt_address, 0);
+    }
+
+    #[test]
+    fn test_parse_rsdp_v2() {
+        let mut data = [0u8; 36];
+        data[0..8].copy_from_slice(b"RSD PTR ");
+        data[15] = 2; // revision 2
+        data[16..20].copy_from_slice(&0xAABBCCDDu32.to_le_bytes());
+        data[20..24].copy_from_slice(&36u32.to_le_bytes());
+        data[24..32].copy_from_slice(&0xDEADBEEF_CAFEBABEu64.to_le_bytes());
+        fix_checksum(&mut data, 8, 20);
+        fix_checksum(&mut data, 32, 36);
+
+        let rsdp = Rsdp::parse(&data).unwrap();
+        assert_eq!(rsdp.revision, 2);
+        assert_eq!(rsdp.rsdt_address, 0xAABBCCDD);
+        assert_eq!(rsdp.xsdt_address, 0xDEADBEEF_CAFEBABE);
+    }
+
+    #[test]
+    fn test_parse_rsdp_bad_signature() {
+        let mut data = [0u8; 20];
+        data[0..8].copy_from_slice(b"NOT RSDP");
+        assert!(Rsdp::parse(&data).is_none());
+    }
+
+    #[test]
+    fn test_parse_rsdp_too_small() {
+        assert!(Rsdp::parse(&[0u8; 10]).is_none());
+    }
+
+    #[test]
+    fn test_parse_rsdp_bad_checksum_v1() {
+        let mut data = [0u8; 20];
+        data[0..8].copy_from_slice(b"RSD PTR ");
+        data[15] = 0;
+        data[16..20].copy_from_slice(&0x12345678u32.to_le_bytes());
+        // Deliberately do not fix the checksum byte.
+        assert!(Rsdp::parse(&data).is_none());
+    }
+
+    #[test]
+    fn test_parse_rsdp_bad_checksum_v2() {
+        let mut data = [0u8; 36];
+        data[0..8].copy_from_slice(b"RSD PTR ");
+        data[15] = 2;
+        data[20..24].copy_from_slice(&36u32.to_le_bytes());
+        fix_checksum(&mut data, 8, 20);
+        // Leave the extended checksum wrong.
+        assert!(Rsdp::parse(&data).is_none());
+    }
+
+    #[test]
+    fn test_find_table_xsdt() {
+        let sdt_hdr_size = size_of::<SdtHeader>();
+
+        // Place the XSDT at a non-zero offset so the revision>=2 &&
+        // xsdt_address!=0 branch is taken (rather than falling back to RSDT).
+        let xsdt_base = 0x100usize;
+        let xsdt_entries = 2;
+        let xsdt_len = sdt_hdr_size + xsdt_entries * 8;
+        let facp_off = xsdt_base + xsdt_len;
+        let mcfg_off = facp_off + sdt_hdr_size;
+        let total = mcfg_off + sdt_hdr_size;
+
+        let mut buf = alloc::vec![0u8; total];
+
+        // XSDT header
+        buf[xsdt_base..xsdt_base + 4].copy_from_slice(b"XSDT");
+        buf[xsdt_base + 4..xsdt_base + 8].copy_from_slice(&(xsdt_len as u32).to_le_bytes());
+
+        // FACP and MCFG table headers
+        buf[facp_off..facp_off + 4].copy_from_slice(b"FACP");
+        buf[mcfg_off..mcfg_off + 4].copy_from_slice(b"MCFG");
+
+        // 8-byte XSDT entries
+        let e0 = xsdt_base + sdt_hdr_size;
+        buf[e0..e0 + 8].copy_from_slice(&(facp_off as u64).to_le_bytes());
+        buf[e0 + 8..e0 + 16].copy_from_slice(&(mcfg_off as u64).to_le_bytes());
+
+        let rsdp = Rsdp {
+            revision: 2,
+            rsdt_address: 0,
+            xsdt_address: xsdt_base as u64,
+        };
+
+        // deref treats addresses as offsets into buf
+        let deref = |addr: u64, len: usize| &buf[addr as usize..addr as usize + len];
+
+        assert_eq!(rsdp.find_table(b"MCFG", &deref), Some(mcfg_off as u64));
+        assert_eq!(rsdp.find_table(b"FACP", &deref), Some(facp_off as u64));
+        assert_eq!(rsdp.find_table(b"HPET", &deref), None);
+    }
+
+    #[test]
+    fn test_find_table_rsdt() {
+        let sdt_hdr_size = size_of::<SdtHeader>();
+
+        // Build RSDT with 2 entries (32-bit pointers)
+        let rsdt_entries = 2;
+        let rsdt_len = sdt_hdr_size + rsdt_entries * 4;
+        let facp_off = rsdt_len;
+        let apic_off = facp_off + sdt_hdr_size;
+        let total = apic_off + sdt_hdr_size;
+
+        let mut buf = alloc::vec![0u8; total];
+
+        buf[0..4].copy_from_slice(b"RSDT");
+        buf[4..8].copy_from_slice(&(rsdt_len as u32).to_le_bytes());
+
+        buf[facp_off..facp_off + 4].copy_from_slice(b"FACP");
+        buf[apic_off..apic_off + 4].copy_from_slice(b"APIC");
+
+        buf[sdt_hdr_size..sdt_hdr_size + 4].copy_from_slice(&(facp_off as u32).to_le_bytes());
+        buf[sdt_hdr_size + 4..sdt_hdr_size + 8].copy_from_slice(&(apic_off as u32).to_le_bytes());
+
+        let rsdp = Rsdp {
+            revision: 0,
+            rsdt_address: 0,
+            xsdt_address: 0,
+        };
+
+        let deref = |addr: u64, len: usize| &buf[addr as usize..addr as usize + len];
+
+        assert_eq!(rsdp.find_table(b"APIC", &deref), Some(apic_off as u64));
+        assert_eq!(rsdp.find_table(b"FACP", &deref), Some(facp_off as u64));
+        assert_eq!(rsdp.find_table(b"MCFG", &deref), None);
+    }
+}

--- a/lace-util/src/elf64.rs
+++ b/lace-util/src/elf64.rs
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+// Copyright (C) 2026, Canonical Ltd.
+// Authors: Mate Kukri <mate.kukri@canonical.com>
+
+//! Minimal ELF64 parser
+//!
+//! Parses ELF64 headers and iterates over program headers.
+
+use zerocopy::{FromBytes, Immutable, KnownLayout};
+
+const ELF_MAGIC: [u8; 4] = *b"\x7fELF";
+const ELFCLASS64: u8 = 2;
+#[cfg(target_endian = "little")]
+const ELFDATA2LSB: u8 = 1;
+#[cfg(target_endian = "big")]
+const ELFDATA2MSB: u8 = 2;
+
+/// ELF program header type: loadable segment.
+pub const PT_LOAD: u32 = 1;
+
+#[repr(C)]
+#[derive(FromBytes, Immutable, KnownLayout)]
+struct Elf64Header {
+    e_ident: [u8; 16],
+    e_type: u16,
+    e_machine: u16,
+    e_version: u32,
+    e_entry: u64,
+    e_phoff: u64,
+    e_shoff: u64,
+    e_flags: u32,
+    e_ehsize: u16,
+    e_phentsize: u16,
+    e_phnum: u16,
+    e_shentsize: u16,
+    e_shnum: u16,
+    e_shstrndx: u16,
+}
+
+/// A parsed ELF64 program header.
+#[derive(Debug, Clone, Copy)]
+pub struct Elf64Phdr {
+    pub p_type: u32,
+    pub p_flags: u32,
+    pub p_offset: u64,
+    pub p_vaddr: u64,
+    pub p_paddr: u64,
+    pub p_filesz: u64,
+    pub p_memsz: u64,
+    pub p_align: u64,
+}
+
+#[repr(C)]
+#[derive(FromBytes, Immutable, KnownLayout)]
+struct RawElf64Phdr {
+    p_type: u32,
+    p_flags: u32,
+    p_offset: u64,
+    p_vaddr: u64,
+    p_paddr: u64,
+    p_filesz: u64,
+    p_memsz: u64,
+    p_align: u64,
+}
+
+/// A parsed ELF64 binary.
+#[derive(Debug)]
+pub struct Elf64<'a> {
+    data: &'a [u8],
+    entry: u64,
+    phoff: usize,
+    phentsize: usize,
+    phnum: usize,
+}
+
+impl<'a> Elf64<'a> {
+    /// Parse an ELF64 binary from a byte slice.
+    pub fn parse(data: &'a [u8]) -> Result<Self, &'static str> {
+        let (ehdr, _) = Elf64Header::read_from_prefix(data).map_err(|_| "ELF header too small")?;
+
+        if ehdr.e_ident[0..4] != ELF_MAGIC {
+            return Err("bad ELF magic");
+        }
+        if ehdr.e_ident[4] != ELFCLASS64 {
+            return Err("not ELF64");
+        }
+        #[cfg(target_endian = "little")]
+        if ehdr.e_ident[5] != ELFDATA2LSB {
+            return Err("not little-endian");
+        }
+        #[cfg(target_endian = "big")]
+        if ehdr.e_ident[5] != ELFDATA2MSB {
+            return Err("not big-endian");
+        }
+
+        let phentsize: usize = ehdr.e_phentsize.into();
+        if phentsize < size_of::<RawElf64Phdr>() {
+            return Err("phentsize too small");
+        }
+
+        // Cast via try_from so a 64-bit `e_phoff` on a 32-bit host doesn't
+        // silently truncate into an in-bounds usize.
+        let phoff = usize::try_from(ehdr.e_phoff).map_err(|_| "phoff too large")?;
+        let phnum: usize = ehdr.e_phnum.into();
+
+        // Validate the program-header table fits inside `data` up front, so
+        // `for_each_phdr` can walk by simple addition without re-checking.
+        let phdr_table_end = phnum
+            .checked_mul(phentsize)
+            .and_then(|bytes| phoff.checked_add(bytes))
+            .ok_or("phdr table overflows usize")?;
+        if phdr_table_end > data.len() {
+            return Err("phdr table out of bounds");
+        }
+
+        Ok(Self {
+            data,
+            entry: ehdr.e_entry,
+            phoff,
+            phentsize,
+            phnum,
+        })
+    }
+
+    /// Entry point address.
+    pub fn entry(&self) -> u64 {
+        self.entry
+    }
+
+    /// Iterate over program headers, calling `f` for each.
+    ///
+    /// The callback returns `true` to continue, `false` to stop.
+    pub fn for_each_phdr(&self, mut f: impl FnMut(&Elf64Phdr) -> bool) -> Result<(), &'static str> {
+        for i in 0..self.phnum {
+            let off = self.phoff + i * self.phentsize;
+            let (raw, _) =
+                RawElf64Phdr::read_from_prefix(self.data.get(off..).ok_or("phdr out of bounds")?)
+                    .map_err(|_| "phdr parse error")?;
+
+            let phdr = Elf64Phdr {
+                p_type: raw.p_type,
+                p_flags: raw.p_flags,
+                p_offset: raw.p_offset,
+                p_vaddr: raw.p_vaddr,
+                p_paddr: raw.p_paddr,
+                p_filesz: raw.p_filesz,
+                p_memsz: raw.p_memsz,
+                p_align: raw.p_align,
+            };
+
+            if !f(&phdr) {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    /// Get the file data for a program header's file portion.
+    pub fn segment_data(&self, phdr: &Elf64Phdr) -> Result<&'a [u8], &'static str> {
+        let off = usize::try_from(phdr.p_offset).map_err(|_| "p_offset too large")?;
+        let len = usize::try_from(phdr.p_filesz).map_err(|_| "p_filesz too large")?;
+        let end = off.checked_add(len).ok_or("segment range overflow")?;
+        self.data.get(off..end).ok_or("segment data out of bounds")
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Build a minimal ELF64 binary with the given PT_LOAD segments.
+    /// Each segment is (p_vaddr, p_paddr, data).
+    fn build_elf64(entry: u64, segments: &[(u64, u64, &[u8])]) -> alloc::vec::Vec<u8> {
+        let ehdr_size = size_of::<Elf64Header>();
+        let phdr_size = size_of::<RawElf64Phdr>();
+        let phoff = ehdr_size;
+        let data_start = ehdr_size + segments.len() * phdr_size;
+
+        let mut buf = alloc::vec![0u8; data_start];
+
+        // ELF header
+        buf[0..4].copy_from_slice(b"\x7fELF");
+        buf[4] = 2; // ELFCLASS64
+        buf[5] = 1; // ELFDATA2LSB
+        buf[6] = 1; // EV_CURRENT
+        // e_type at 16
+        buf[16..18].copy_from_slice(&2u16.to_le_bytes()); // ET_EXEC
+        // e_machine at 18
+        buf[18..20].copy_from_slice(&62u16.to_le_bytes()); // EM_X86_64
+        // e_version at 20
+        buf[20..24].copy_from_slice(&1u32.to_le_bytes());
+        // e_entry at 24
+        buf[24..32].copy_from_slice(&entry.to_le_bytes());
+        // e_phoff at 32
+        buf[32..40].copy_from_slice(&(phoff as u64).to_le_bytes());
+        // e_ehsize at 52
+        buf[52..54].copy_from_slice(&(ehdr_size as u16).to_le_bytes());
+        // e_phentsize at 54
+        buf[54..56].copy_from_slice(&(phdr_size as u16).to_le_bytes());
+        // e_phnum at 56
+        buf[56..58].copy_from_slice(&(segments.len() as u16).to_le_bytes());
+
+        // Program headers and data
+        for (i, &(vaddr, paddr, data)) in segments.iter().enumerate() {
+            let file_offset = buf.len();
+            buf.extend_from_slice(data);
+
+            let phdr_off = phoff + i * phdr_size;
+            // p_type = PT_LOAD (1)
+            buf[phdr_off..phdr_off + 4].copy_from_slice(&1u32.to_le_bytes());
+            // p_offset
+            buf[phdr_off + 8..phdr_off + 16].copy_from_slice(&(file_offset as u64).to_le_bytes());
+            // p_vaddr
+            buf[phdr_off + 16..phdr_off + 24].copy_from_slice(&vaddr.to_le_bytes());
+            // p_paddr
+            buf[phdr_off + 24..phdr_off + 32].copy_from_slice(&paddr.to_le_bytes());
+            // p_filesz
+            buf[phdr_off + 32..phdr_off + 40].copy_from_slice(&(data.len() as u64).to_le_bytes());
+            // p_memsz (same as filesz for simplicity)
+            buf[phdr_off + 40..phdr_off + 48].copy_from_slice(&(data.len() as u64).to_le_bytes());
+        }
+
+        buf
+    }
+
+    #[test]
+    fn test_parse_valid_elf() {
+        let elf_data = build_elf64(0x100000, &[(0x100000, 0x100000, b"hello")]);
+        let elf = Elf64::parse(&elf_data).unwrap();
+        assert_eq!(elf.entry(), 0x100000);
+    }
+
+    #[test]
+    fn test_bad_magic() {
+        let mut data = build_elf64(0, &[]);
+        data[0] = 0; // corrupt magic
+        assert!(Elf64::parse(&data).is_err());
+    }
+
+    #[test]
+    fn test_not_elf64() {
+        let mut data = build_elf64(0, &[]);
+        data[4] = 1; // ELFCLASS32
+        assert_eq!(Elf64::parse(&data).unwrap_err(), "not ELF64");
+    }
+
+    #[test]
+    fn test_not_little_endian() {
+        let mut data = build_elf64(0, &[]);
+        data[5] = 2; // ELFDATA2MSB
+        assert_eq!(Elf64::parse(&data).unwrap_err(), "not little-endian");
+    }
+
+    #[test]
+    fn test_program_headers() {
+        let seg1 = b"segment one data";
+        let seg2 = b"two";
+        let elf_data = build_elf64(
+            0x200000,
+            &[(0x100000, 0x100000, seg1), (0x200000, 0x200000, seg2)],
+        );
+        let elf = Elf64::parse(&elf_data).unwrap();
+
+        let mut phdrs = alloc::vec::Vec::new();
+        elf.for_each_phdr(|phdr| {
+            phdrs.push(*phdr);
+            true
+        })
+        .unwrap();
+
+        assert_eq!(phdrs.len(), 2);
+        assert_eq!(phdrs[0].p_type, PT_LOAD);
+        assert_eq!(phdrs[0].p_vaddr, 0x100000);
+        assert_eq!(phdrs[0].p_filesz, seg1.len() as u64);
+        assert_eq!(phdrs[1].p_vaddr, 0x200000);
+
+        // Check segment data
+        let data = elf.segment_data(&phdrs[0]).unwrap();
+        assert_eq!(data, seg1);
+    }
+
+    #[test]
+    fn test_too_small() {
+        assert!(Elf64::parse(&[0; 10]).is_err());
+    }
+}

--- a/lace-util/src/lib.rs
+++ b/lace-util/src/lib.rs
@@ -13,6 +13,8 @@ pub mod chid;
 pub mod chid_mapping;
 pub mod chid_matcher;
 pub mod edid;
+#[cfg(feature = "firmware")]
+pub mod elf64;
 #[cfg(feature = "grub")]
 pub mod grub;
 pub mod peimage;

--- a/lace-util/src/lib.rs
+++ b/lace-util/src/lib.rs
@@ -6,6 +6,8 @@
 
 extern crate alloc;
 
+#[cfg(feature = "firmware")]
+pub mod acpi;
 pub mod bls;
 pub mod chid;
 pub mod chid_mapping;


### PR DESCRIPTION
This pull requests adds basic ACPI and ELF64 parsers to lace-util for the upcoming lace VM firmware implementation.