### PR TITLE
Introduce lace-drivers crate for low-level architecture primitives and hardware drivers

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,6 +16,13 @@ They use the following library crates:
 * `lace-util` - Platform-independent utilities
 * `lace-util-derive` - Platform-independent macros
 
+### Rust Edition
+
+The workspace uses **Rust edition 2024**. Notably, `size_of`,
+`size_of_val`, `align_of`, and `align_of_val` are in the prelude and
+do **not** need to be imported from `core::mem` / `std::mem`. Do not
+flag unqualified uses of these as missing imports.
+
 ### Build System
 
 The project uses a **Cargo workspace**.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "lace-drivers"
+version = "0.1.0"
+dependencies = [
+ "lace-util",
+ "log",
+ "zerocopy",
+]
+
+[[package]]
 name = "lace-platform"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784a4df722dc6267a04af36895398f59d21d07dce47232adf31ec0ff2fa45e67"
 
 [[package]]
+name = "flashedit"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "lace-util",
+ "zerocopy",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "lace-drivers",
     "lace-platform",
     "lace-speedboot",
     "lace-stubble",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "lace-util-derive-impl",
     "tools/collect-hwids",
     "tools/fakeedid",
+    "tools/flashedit",
     "tools/pewrap",
     "tools/xtask",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -116,6 +116,7 @@ exceptions = [
     { allow = ["GPL-2.0-only"], crate = "lace-util-derive" },
     { allow = ["GPL-2.0-only"], crate = "lace-util-derive-impl" },
     { allow = ["GPL-2.0-only"], crate = "flashedit" },
+    { allow = ["GPL-2.0-only"], crate = "lace-drivers" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,

--- a/deny.toml
+++ b/deny.toml
@@ -115,6 +115,7 @@ exceptions = [
     { allow = ["GPL-2.0-only"], crate = "lace-util" },
     { allow = ["GPL-2.0-only"], crate = "lace-util-derive" },
     { allow = ["GPL-2.0-only"], crate = "lace-util-derive-impl" },
+    { allow = ["GPL-2.0-only"], crate = "flashedit" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,

--- a/lace-drivers/Cargo.toml
+++ b/lace-drivers/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "lace-drivers"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+lace-util = { path = "../lace-util", default-features = false }
+log.workspace = true
+zerocopy = { workspace = true, features = ["derive"] }

--- a/lace-drivers/src/fw_cfg.rs
+++ b/lace-drivers/src/fw_cfg.rs
@@ -1,0 +1,358 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+// Copyright (C) 2026, Canonical Ltd.
+// Authors: Mate Kukri <mate.kukri@canonical.com>
+
+//! QEMU fw_cfg device driver (DMA interface).
+//!
+//! The byte-by-byte port I/O transport is intentionally not supported: it
+//! would only matter for QEMU versions predating 2.9, and we target modern
+//! QEMU exclusively. [`FwCfg::probe`] fails with
+//! [`FwCfgError::DmaUnsupported`] if the device is missing the DMA
+//! interface.
+//!
+//! Currently only the x86 port I/O transport for the DMA register is
+//! implemented; MMIO (arm64, riscv) can be added later alongside the port
+//! constants.
+
+use alloc::collections::BTreeMap;
+use alloc::{string::String, vec, vec::Vec};
+use lace_util::Display;
+use zerocopy::byteorder::{BE, U16, U32, U64};
+use zerocopy::{FromBytes, FromZeros, Immutable, IntoBytes, KnownLayout};
+
+// fw_cfg selector keys
+const FW_CFG_SIGNATURE: u16 = 0x0000;
+const FW_CFG_ID: u16 = 0x0001;
+const FW_CFG_FILE_DIR: u16 = 0x0019;
+
+const FW_CFG_SIGNATURE_BYTES: [u8; 4] = *b"QEMU";
+const FW_CFG_VERSION_DMA: u32 = 1 << 1;
+
+// x86 I/O ports
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+const SELECTOR_PORT: u16 = 0x0510;
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+const DATA_PORT: u16 = 0x0511;
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+const DMA_ADDR_HIGH_PORT: u16 = 0x0514;
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+const DMA_ADDR_LOW_PORT: u16 = 0x0518;
+
+// DMA control bits (in the big-endian control word, low 16 bits).
+const DMA_CTL_ERROR: u32 = 0x01;
+const DMA_CTL_READ: u32 = 0x02;
+// SKIP (0x04) and WRITE (0x10) are defined by the spec but unused here.
+const DMA_CTL_SELECT: u32 = 0x08;
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+fn write_selector(key: u16) {
+    unsafe { crate::x86::port_io::outw(SELECTOR_PORT, key) };
+}
+
+/// Byte-port read, used only by [`FwCfg::probe`] to read the signature and
+/// feature-id before the DMA interface is confirmed.
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+fn read_data_byte() -> u8 {
+    unsafe { crate::x86::port_io::inb(DATA_PORT) }
+}
+
+/// Errors returned by the fw_cfg driver.
+#[derive(Debug, Display)]
+pub enum FwCfgProbeError {
+    #[display("fw_cfg device not present")]
+    NotPresent,
+    #[display("fw_cfg DMA interface not supported (QEMU too old)")]
+    DmaUnsupported,
+}
+
+/// Raw fw_cfg directory entry (all multi-byte fields are big-endian).
+#[repr(C)]
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout)]
+pub struct FwCfgFile {
+    size: U32<BE>,
+    select: U16<BE>,
+    _reserved: U16<BE>,
+    name: [u8; 56],
+}
+
+impl FwCfgFile {
+    /// Get the file size.
+    pub fn size(&self) -> u32 {
+        self.size.get()
+    }
+
+    /// Get the file selector.
+    pub fn select(&self) -> u16 {
+        self.select.get()
+    }
+
+    /// Get the file name.
+    pub fn name(&self) -> &[u8] {
+        trim_name(&self.name)
+    }
+}
+
+/// Trim triling NUL bytes (if any) from a fw_cfg file name.
+fn trim_name(name: &[u8]) -> &[u8] {
+    let nul = name.iter().position(|&b| b == 0).unwrap_or(name.len());
+    &name[..nul]
+}
+
+/// DMA access struct shared with QEMU: all fields are big-endian.
+#[repr(C)]
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout)]
+struct DmaAccess {
+    control: U32<BE>,
+    length: U32<BE>,
+    address: U64<BE>,
+}
+
+/// Handle to the QEMU fw_cfg device.
+pub struct FwCfg {
+    _private: (),
+}
+
+impl FwCfg {
+    /// Probe for the fw_cfg device and its DMA interface.
+    pub fn probe() -> Result<Self, FwCfgProbeError> {
+        // Signature check via byte port I/O — the only byte-path reads we do.
+        write_selector(FW_CFG_SIGNATURE);
+        let sig = [
+            read_data_byte(),
+            read_data_byte(),
+            read_data_byte(),
+            read_data_byte(),
+        ];
+        if sig != FW_CFG_SIGNATURE_BYTES {
+            return Err(FwCfgProbeError::NotPresent);
+        }
+
+        // FW_CFG_ID is a little-endian u32; bit 1 signals DMA support.
+        write_selector(FW_CFG_ID);
+        let id_bytes = [
+            read_data_byte(),
+            read_data_byte(),
+            read_data_byte(),
+            read_data_byte(),
+        ];
+        let id = u32::from_le_bytes(id_bytes);
+        if id & FW_CFG_VERSION_DMA == 0 {
+            return Err(FwCfgProbeError::DmaUnsupported);
+        }
+
+        Ok(Self { _private: () })
+    }
+
+    /// Issue a single DMA transaction against `buf` and spin until it
+    /// completes. Assumes virtual == physical for the slice and the
+    /// on-stack access struct, which holds across our bootblock, bios
+    /// entry, and virt firmware (all identity-mapped during boot).
+    fn dma(&self, control: u32, buf: &mut [u8]) {
+        let mut access = DmaAccess {
+            control: control.into(),
+            length: (buf.len() as u32).into(),
+            address: (buf.as_mut_ptr() as u64).into(),
+        };
+        let access_addr = &raw mut access as u64;
+
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        unsafe {
+            // 64-bit big-endian address register written as two 32-bit
+            // big-endian halves. The write to the low half kicks off the
+            // transfer.
+            crate::x86::port_io::outl(DMA_ADDR_HIGH_PORT, ((access_addr >> 32) as u32).to_be());
+            crate::x86::port_io::outl(DMA_ADDR_LOW_PORT, (access_addr as u32).to_be());
+        }
+
+        // Spin until QEMU clears the control word (or sets the error bit).
+        loop {
+            let ctl = unsafe { core::ptr::read_volatile(&raw const access.control) }.get();
+            if ctl & DMA_CTL_ERROR != 0 {
+                panic!("fw_cfg DMA transfer failed")
+            }
+            if ctl == 0 {
+                break;
+            }
+            core::hint::spin_loop();
+        }
+    }
+
+    /// Read the contents of the given key into `buf` in a single DMA
+    /// transaction. Rewinds to offset 0 (via the `SELECT` control bit).
+    pub fn read_key(&self, key: u16, buf: &mut [u8]) {
+        let control = DMA_CTL_SELECT | DMA_CTL_READ | ((key as u32) << 16);
+        self.dma(control, buf);
+    }
+
+    /// Continue reading from the currently selected key / file without
+    /// rewinding. Must follow a prior [`read_key`](Self::read_key) /
+    /// [`read_file`](Self::read_file) or another `read_continuation`.
+    /// Lets callers stream a large file through a fixed-size buffer.
+    pub fn read_continuation(&self, buf: &mut [u8]) {
+        self.dma(DMA_CTL_READ, buf);
+    }
+
+    /// Find a file by name.
+    pub fn find_file(&self, name: &[u8]) -> Option<FwCfgFile> {
+        // Read the 4 byte big-endian entry count
+        let mut count_buf = [0u8; 4];
+        self.read_key(FW_CFG_FILE_DIR, &mut count_buf);
+        let count = u32::from_be_bytes(count_buf) as usize;
+
+        // Read file entries one-by-one
+        let mut file = FwCfgFile::new_zeroed();
+        for _ in 0..count {
+            self.read_continuation(file.as_mut_bytes());
+            if file.name() == name {
+                return Some(file);
+            }
+        }
+        None
+    }
+
+    /// Read a file into the provided buffer.
+    pub fn read_file(&self, file: &FwCfgFile, buf: &mut [u8]) {
+        self.read_key(file.select(), buf);
+    }
+
+    /// Read a file into a new Vec of its full size.
+    pub fn read_file_to_vec(&self, file: &FwCfgFile) -> Vec<u8> {
+        let mut buf = vec![0u8; file.size() as usize];
+        self.read_file(file, &mut buf);
+        buf
+    }
+
+    /// Process the ACPI table-loader (`etc/table-loader`) to load and link
+    /// ACPI tables into memory.
+    ///
+    /// Each table is allocated via the caller-provided `alloc_table`
+    /// closure, which takes `(size, align)` and returns a slice the
+    /// driver writes the table data into. The caller is responsible for
+    /// placing these allocations in memory that will be preserved across
+    /// OS handoff (e.g. firmware-managed `AcpiNvs` pages); the driver
+    /// never touches the system heap.
+    ///
+    /// Returns the RSDP slice so the caller can record its physical
+    /// address, or `None` if no table-loader file is present.
+    pub fn load_acpi_tables(
+        &self,
+        mut alloc_table: impl FnMut(usize, usize) -> &'static mut [u8],
+    ) -> Option<&'static mut [u8]> {
+        const LOADER_ENTRY_SIZE: usize = 128;
+        const LOADER_CMD_ALLOCATE: u32 = 0x1;
+        const LOADER_CMD_ADD_POINTER: u32 = 0x2;
+        const LOADER_CMD_ADD_CHECKSUM: u32 = 0x3;
+        const LOADER_CMD_WRITE_POINTER: u32 = 0x4;
+
+        let loader_file = self.find_file(b"etc/table-loader")?;
+        let loader_data = self.read_file_to_vec(&loader_file);
+
+        let mut allocations: BTreeMap<&[u8], &'static mut [u8]> = BTreeMap::new();
+
+        for entry_bytes in loader_data.chunks_exact(LOADER_ENTRY_SIZE) {
+            let command = u32::from_le_bytes(entry_bytes[0..4].try_into().unwrap());
+            let payload = &entry_bytes[4..];
+
+            match command {
+                LOADER_CMD_ALLOCATE => {
+                    let name = trim_name(&payload[..56]);
+                    let align = u32::from_le_bytes(payload[56..60].try_into().unwrap());
+                    let align = align.max(1) as usize;
+
+                    // Look up the file size without alloc, then let the
+                    // caller provide the backing memory with the right
+                    // memory type / alignment, and stream the file data
+                    // into it directly.
+                    let file = self.find_file(name).unwrap();
+                    let size = file.size() as usize;
+                    let region = alloc_table(size, align);
+                    self.read_file(&file, region);
+                    log::debug!(
+                        "table-loader: allocated {} at {:p}",
+                        String::from_utf8_lossy(name),
+                        region.as_ptr()
+                    );
+                    allocations.insert(name, region);
+                }
+                LOADER_CMD_ADD_POINTER => {
+                    let dest_file = trim_name(&payload[..56]);
+                    let src_file = trim_name(&payload[56..112]);
+                    let offset = u32::from_le_bytes(payload[112..116].try_into().unwrap()) as usize;
+                    let size = payload[116] as usize;
+
+                    let src_addr = allocations
+                        .get(src_file)
+                        .unwrap_or_else(|| {
+                            panic!(
+                                "table-loader: src not found: {}",
+                                String::from_utf8_lossy(src_file)
+                            )
+                        })
+                        .as_ptr() as u64;
+                    let dest = allocations.get_mut(dest_file).unwrap_or_else(|| {
+                        panic!(
+                            "table-loader: dest not found: {}",
+                            String::from_utf8_lossy(dest_file)
+                        )
+                    });
+
+                    // Add src base address to the value at dest[offset..offset+size]
+                    match size {
+                        1 => {
+                            let v = dest[offset];
+                            dest[offset] = v.wrapping_add(src_addr as u8);
+                        }
+                        2 => {
+                            let v =
+                                u16::from_le_bytes(dest[offset..offset + 2].try_into().unwrap());
+                            dest[offset..offset + 2]
+                                .copy_from_slice(&v.wrapping_add(src_addr as u16).to_le_bytes());
+                        }
+                        4 => {
+                            let v =
+                                u32::from_le_bytes(dest[offset..offset + 4].try_into().unwrap());
+                            dest[offset..offset + 4]
+                                .copy_from_slice(&v.wrapping_add(src_addr as u32).to_le_bytes());
+                        }
+                        8 => {
+                            let v =
+                                u64::from_le_bytes(dest[offset..offset + 8].try_into().unwrap());
+                            dest[offset..offset + 8]
+                                .copy_from_slice(&v.wrapping_add(src_addr).to_le_bytes());
+                        }
+                        _ => panic!("table-loader: unsupported pointer size: {}", size),
+                    }
+                }
+                LOADER_CMD_ADD_CHECKSUM => {
+                    let file = trim_name(&payload[..56]);
+                    let cksum_offset =
+                        u32::from_le_bytes(payload[56..60].try_into().unwrap()) as usize;
+                    let start = u32::from_le_bytes(payload[60..64].try_into().unwrap()) as usize;
+                    let length = u32::from_le_bytes(payload[64..68].try_into().unwrap()) as usize;
+
+                    let region = allocations.get_mut(file).unwrap_or_else(|| {
+                        panic!(
+                            "table-loader: file not found: {}",
+                            String::from_utf8_lossy(file)
+                        )
+                    });
+
+                    // Zero the checksum byte first
+                    region[cksum_offset] = 0;
+                    // Sum all bytes in the range
+                    let sum: u8 = region[start..start + length]
+                        .iter()
+                        .fold(0u8, |acc, &b| acc.wrapping_add(b));
+                    // Store negated sum so total sums to zero
+                    region[cksum_offset] = 0u8.wrapping_sub(sum);
+                }
+                LOADER_CMD_WRITE_POINTER => {
+                    // Write pointer back to fw_cfg — not needed for our use case
+                }
+                _ => {} // Skip unknown commands
+            }
+        }
+
+        allocations.remove(b"etc/acpi/rsdp".as_ref())
+    }
+}

--- a/lace-drivers/src/lib.rs
+++ b/lace-drivers/src/lib.rs
@@ -13,3 +13,4 @@ pub mod x86;
 
 pub mod fw_cfg;
 pub mod pci;
+pub mod virtio;

--- a/lace-drivers/src/lib.rs
+++ b/lace-drivers/src/lib.rs
@@ -10,3 +10,5 @@ extern crate alloc;
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 pub mod x86;
+
+pub mod pci;

--- a/lace-drivers/src/lib.rs
+++ b/lace-drivers/src/lib.rs
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+// Copyright (C) 2026, Canonical Ltd.
+// Authors: Mate Kukri <mate.kukri@canonical.com>
+
+//! Hardware drivers and device access for bare-metal environments
+
+#![cfg_attr(not(test), no_std)]
+
+extern crate alloc;
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub mod x86;

--- a/lace-drivers/src/lib.rs
+++ b/lace-drivers/src/lib.rs
@@ -11,4 +11,5 @@ extern crate alloc;
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 pub mod x86;
 
+pub mod fw_cfg;
 pub mod pci;

--- a/lace-drivers/src/pci.rs
+++ b/lace-drivers/src/pci.rs
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+// Copyright (C) 2026, Canonical Ltd.
+// Authors: Mate Kukri <mate.kukri@canonical.com>
+
+//! PCI configuration space access and device enumeration
+//!
+//! Provides generic ECAM (Enhanced Configuration Access Mechanism) based PCI
+//! config space access. x86 legacy I/O port access is in [`crate::x86::pci_legacy`].
+
+/// PCI ECAM (Enhanced Configuration Access Mechanism) accessor.
+///
+/// ECAM maps PCI configuration space to a contiguous MMIO region where each
+/// device function gets 4KB at `base + (bus << 20 | dev << 15 | func << 12)`.
+pub struct Ecam {
+    base: u64,
+}
+
+impl Ecam {
+    /// Create a new ECAM accessor with the given MMIO base address.
+    pub fn new(base: u64) -> Self {
+        Self { base }
+    }
+
+    /// Calculate the MMIO address for a given BDF and register offset.
+    fn addr(&self, bus: u8, dev: u8, func: u8, offset: u16) -> *mut u8 {
+        let addr = self.base
+            + ((bus as u64) << 20)
+            + ((dev as u64) << 15)
+            + ((func as u64) << 12)
+            + (offset as u64);
+        addr as *mut u8
+    }
+
+    pub fn read_u8(&self, bus: u8, dev: u8, func: u8, offset: u16) -> u8 {
+        unsafe { core::ptr::read_volatile(self.addr(bus, dev, func, offset)) }
+    }
+
+    pub fn read_u16(&self, bus: u8, dev: u8, func: u8, offset: u16) -> u16 {
+        unsafe { core::ptr::read_volatile(self.addr(bus, dev, func, offset) as *const u16) }
+    }
+
+    pub fn read_u32(&self, bus: u8, dev: u8, func: u8, offset: u16) -> u32 {
+        unsafe { core::ptr::read_volatile(self.addr(bus, dev, func, offset) as *const u32) }
+    }
+
+    pub fn write_u8(&self, bus: u8, dev: u8, func: u8, offset: u16, value: u8) {
+        unsafe { core::ptr::write_volatile(self.addr(bus, dev, func, offset), value) }
+    }
+
+    pub fn write_u16(&self, bus: u8, dev: u8, func: u8, offset: u16, value: u16) {
+        unsafe { core::ptr::write_volatile(self.addr(bus, dev, func, offset) as *mut u16, value) }
+    }
+
+    pub fn write_u32(&self, bus: u8, dev: u8, func: u8, offset: u16, value: u32) {
+        unsafe { core::ptr::write_volatile(self.addr(bus, dev, func, offset) as *mut u32, value) }
+    }
+}
+
+/// A discovered PCI device.
+#[derive(Debug, Clone, Copy)]
+pub struct PciDevice {
+    pub bus: u8,
+    pub dev: u8,
+    pub func: u8,
+    pub vendor_id: u16,
+    pub device_id: u16,
+    pub class_code: u8,
+    pub subclass: u8,
+    pub header_type: u8,
+}
+
+/// Enumerate all PCI devices on a bus (single-segment, no bridge traversal).
+pub fn enumerate_bus(ecam: &Ecam, bus: u8) -> alloc::vec::Vec<PciDevice> {
+    let mut devices = alloc::vec::Vec::new();
+
+    for dev in 0..32 {
+        let vendor_id = ecam.read_u16(bus, dev, 0, 0x00);
+        if vendor_id == 0xFFFF {
+            continue;
+        }
+
+        let header_type = ecam.read_u8(bus, dev, 0, 0x0E);
+        let max_func = if header_type & 0x80 != 0 { 8 } else { 1 };
+
+        for func in 0..max_func {
+            let vendor_id = ecam.read_u16(bus, dev, func, 0x00);
+            if vendor_id == 0xFFFF {
+                continue;
+            }
+
+            let device_id = ecam.read_u16(bus, dev, func, 0x02);
+            let class_code = ecam.read_u8(bus, dev, func, 0x0B);
+            let subclass = ecam.read_u8(bus, dev, func, 0x0A);
+            let header_type = ecam.read_u8(bus, dev, func, 0x0E) & 0x7F;
+
+            devices.push(PciDevice {
+                bus,
+                dev,
+                func,
+                vendor_id,
+                device_id,
+                class_code,
+                subclass,
+                header_type,
+            });
+        }
+    }
+
+    devices
+}
+
+/// Read a BAR (Base Address Register) value and return the MMIO base address.
+/// Returns None for I/O BARs or unassigned BARs.
+pub fn read_bar_mmio64(ecam: &Ecam, dev: &PciDevice, bar_index: u8) -> Option<u64> {
+    let offset = 0x10 + (bar_index as u16) * 4;
+    let low = ecam.read_u32(dev.bus, dev.dev, dev.func, offset);
+
+    if low & 1 != 0 {
+        return None;
+    }
+
+    let bar_type = (low >> 1) & 3;
+    match bar_type {
+        0 => {
+            let addr = low & 0xFFFFFFF0;
+            if addr == 0 { None } else { Some(addr as u64) }
+        }
+        2 => {
+            let high = ecam.read_u32(dev.bus, dev.dev, dev.func, offset + 4);
+            let addr = ((high as u64) << 32) | (low & 0xFFFFFFF0) as u64;
+            if addr == 0 { None } else { Some(addr) }
+        }
+        _ => None,
+    }
+}
+
+/// Simple PCI BAR allocator.
+///
+/// Assigns MMIO addresses to unassigned BARs from a given memory window.
+/// Handles both 32-bit and 64-bit memory BARs. Skips I/O BARs.
+pub struct BarAllocator {
+    mmio_next: u64,
+    mmio_end: u64,
+}
+
+impl BarAllocator {
+    /// Create a new BAR allocator with the given MMIO window.
+    pub fn new(mmio_base: u64, mmio_end: u64) -> Self {
+        Self {
+            mmio_next: mmio_base,
+            mmio_end,
+        }
+    }
+
+    /// Assign BARs for all devices on a bus.
+    ///
+    /// Also enables memory space access and bus mastering for each device.
+    pub fn assign_bars(&mut self, ecam: &Ecam, devices: &[PciDevice]) {
+        for dev in devices {
+            let max_bars: u8 = if dev.header_type == 0 { 6 } else { 2 };
+            let mut bar = 0u8;
+            while bar < max_bars {
+                let offset = 0x10 + (bar as u16) * 4;
+                let orig = ecam.read_u32(dev.bus, dev.dev, dev.func, offset);
+
+                if orig & 1 != 0 {
+                    bar += 1;
+                    continue;
+                }
+
+                let is_64bit = (orig >> 1) & 3 == 2;
+
+                ecam.write_u32(dev.bus, dev.dev, dev.func, offset, 0xFFFFFFFF);
+                if is_64bit {
+                    ecam.write_u32(dev.bus, dev.dev, dev.func, offset + 4, 0xFFFFFFFF);
+                }
+                let size_low = ecam.read_u32(dev.bus, dev.dev, dev.func, offset);
+                let size_high = if is_64bit {
+                    ecam.read_u32(dev.bus, dev.dev, dev.func, offset + 4)
+                } else {
+                    0
+                };
+
+                ecam.write_u32(dev.bus, dev.dev, dev.func, offset, orig);
+                if is_64bit {
+                    let orig_high = ecam.read_u32(dev.bus, dev.dev, dev.func, offset + 4);
+                    ecam.write_u32(dev.bus, dev.dev, dev.func, offset + 4, orig_high);
+                }
+
+                let mask = if is_64bit {
+                    let combined = ((size_high as u64) << 32) | (size_low & 0xFFFFFFF0) as u64;
+                    if combined == 0 {
+                        bar += if is_64bit { 2 } else { 1 };
+                        continue;
+                    }
+                    combined
+                } else {
+                    let masked = size_low & 0xFFFFFFF0;
+                    if masked == 0 {
+                        bar += 1;
+                        continue;
+                    }
+                    masked as u64
+                };
+                let size = (!mask).wrapping_add(1);
+
+                let aligned = (self.mmio_next + size - 1) & !(size - 1);
+                if aligned + size > self.mmio_end {
+                    bar += if is_64bit { 2 } else { 1 };
+                    continue;
+                }
+
+                ecam.write_u32(dev.bus, dev.dev, dev.func, offset, aligned as u32);
+                if is_64bit {
+                    ecam.write_u32(
+                        dev.bus,
+                        dev.dev,
+                        dev.func,
+                        offset + 4,
+                        (aligned >> 32) as u32,
+                    );
+                }
+                self.mmio_next = aligned + size;
+
+                bar += if is_64bit { 2 } else { 1 };
+            }
+
+            let cmd = ecam.read_u16(dev.bus, dev.dev, dev.func, 0x04);
+            ecam.write_u16(dev.bus, dev.dev, dev.func, 0x04, cmd | 0x06);
+        }
+    }
+}

--- a/lace-drivers/src/virtio/blk.rs
+++ b/lace-drivers/src/virtio/blk.rs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+// Copyright (C) 2026, Canonical Ltd.
+// Authors: Mate Kukri <mate.kukri@canonical.com>
+
+//! Virtio block device driver
+
+use alloc::boxed::Box;
+
+use crate::pci::{Ecam, PciDevice};
+
+use super::{VRING_DESC_F_NEXT, VRING_DESC_F_WRITE, VirtioDevice};
+
+// Virtio-blk request types
+const VIRTIO_BLK_T_IN: u32 = 0; // Read
+#[allow(dead_code)]
+const VIRTIO_BLK_T_OUT: u32 = 1; // Write
+
+// Virtio-blk status codes
+const VIRTIO_BLK_S_OK: u8 = 0;
+
+// Virtio-blk feature bits
+const VIRTIO_BLK_F_BLK_SIZE: u64 = 1 << 6;
+
+// Virtio-blk config offsets (all little-endian)
+const CFG_CAPACITY: usize = 0; // u64: capacity in 512-byte sectors
+const CFG_BLK_SIZE: usize = 20; // u32: block size (if feature negotiated)
+
+/// Virtio-blk request header.
+#[repr(C)]
+struct VirtioBlkReqHeader {
+    type_: u32,
+    _reserved: u32,
+    sector: u64,
+}
+
+/// Error from a virtio-blk operation.
+#[derive(Debug)]
+pub struct VirtioBlkError;
+
+/// Virtio block device.
+pub struct VirtioBlkDevice {
+    dev: VirtioDevice,
+    capacity: u64,
+    blk_size: u32,
+}
+
+impl VirtioBlkDevice {
+    /// Initialize a virtio-blk device from a PCI device.
+    pub fn new(ecam: &Ecam, pci_dev: &PciDevice) -> Option<Self> {
+        let dev = VirtioDevice::new(ecam, pci_dev, VIRTIO_BLK_F_BLK_SIZE)?;
+
+        let capacity: u64 = unsafe { dev.read_device_config(CFG_CAPACITY) };
+        let blk_size: u32 = unsafe { dev.read_device_config(CFG_BLK_SIZE) };
+        let blk_size = if blk_size == 0 { 512 } else { blk_size };
+
+        Some(Self {
+            dev,
+            capacity,
+            blk_size,
+        })
+    }
+
+    /// Capacity in 512-byte sectors.
+    pub fn capacity(&self) -> u64 {
+        self.capacity
+    }
+
+    /// Physical block size in bytes.
+    pub fn block_size(&self) -> u32 {
+        self.blk_size
+    }
+
+    /// Read sectors (512 bytes each) starting at the given LBA into `buf`.
+    pub fn read_sectors(&mut self, sector: u64, buf: &mut [u8]) -> Result<(), VirtioBlkError> {
+        let vq = self.dev.queue_mut(0);
+
+        let hdr_desc = vq.alloc_desc();
+        let data_desc = vq.alloc_desc();
+        let status_desc = vq.alloc_desc();
+
+        let header = VirtioBlkReqHeader {
+            type_: VIRTIO_BLK_T_IN,
+            _reserved: 0,
+            sector,
+        };
+        let header_box = Box::new(header);
+        let header_ptr = Box::into_raw(header_box);
+
+        let mut status: u8 = 0xFF;
+
+        unsafe {
+            let desc_base = vq.desc;
+
+            let d = &mut *desc_base.add(hdr_desc as usize);
+            d.addr = header_ptr as u64;
+            d.len = size_of::<VirtioBlkReqHeader>() as u32;
+            d.flags = VRING_DESC_F_NEXT;
+            d.next = data_desc;
+
+            let d = &mut *desc_base.add(data_desc as usize);
+            d.addr = buf.as_mut_ptr() as u64;
+            d.len = buf.len() as u32;
+            d.flags = VRING_DESC_F_WRITE | VRING_DESC_F_NEXT;
+            d.next = status_desc;
+
+            let d = &mut *desc_base.add(status_desc as usize);
+            d.addr = &raw mut status as u64;
+            d.len = 1;
+            d.flags = VRING_DESC_F_WRITE;
+            d.next = 0;
+        }
+
+        vq.submit(hdr_desc);
+        let (_id, _len) = vq.poll_used();
+
+        vq.free_desc(status_desc);
+        vq.free_desc(data_desc);
+        vq.free_desc(hdr_desc);
+
+        let _ = unsafe { Box::from_raw(header_ptr) };
+
+        if status != VIRTIO_BLK_S_OK {
+            return Err(VirtioBlkError);
+        }
+
+        Ok(())
+    }
+}

--- a/lace-drivers/src/virtio/mod.rs
+++ b/lace-drivers/src/virtio/mod.rs
@@ -1,0 +1,425 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+// Copyright (C) 2026, Canonical Ltd.
+// Authors: Mate Kukri <mate.kukri@canonical.com>
+
+//! Virtio device driver (modern 1.0+ PCI transport)
+
+use core::sync::atomic::{Ordering, fence};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+
+use crate::pci::{Ecam, PciDevice, read_bar_mmio64};
+
+pub mod blk;
+
+// Virtio PCI capability types
+const VIRTIO_PCI_CAP_COMMON_CFG: u8 = 1;
+const VIRTIO_PCI_CAP_NOTIFY_CFG: u8 = 2;
+const VIRTIO_PCI_CAP_ISR_CFG: u8 = 3;
+const VIRTIO_PCI_CAP_DEVICE_CFG: u8 = 4;
+
+// Virtio device status bits
+const VIRTIO_STATUS_ACKNOWLEDGE: u8 = 1;
+const VIRTIO_STATUS_DRIVER: u8 = 2;
+const VIRTIO_STATUS_DRIVER_OK: u8 = 4;
+const VIRTIO_STATUS_FEATURES_OK: u8 = 8;
+
+// Virtio feature bits
+const VIRTIO_F_VERSION_1: u64 = 1 << 32;
+
+// Vring descriptor flags
+const VRING_DESC_F_NEXT: u16 = 1;
+const VRING_DESC_F_WRITE: u16 = 2;
+
+// PCI capability ID for vendor-specific
+const PCI_CAP_ID_VNDR: u8 = 0x09;
+
+/// Resolved MMIO addresses for a virtio PCI device's capability regions.
+struct VirtioPciRegions {
+    common: *mut u8,
+    notify: *mut u8,
+    notify_off_multiplier: u32,
+    _isr: *mut u8,
+    device: *mut u8,
+}
+
+/// Walk PCI capabilities to find virtio-specific regions.
+fn find_virtio_pci_regions(ecam: &Ecam, dev: &PciDevice) -> Option<VirtioPciRegions> {
+    let mut common = None;
+    let mut notify = None;
+    let mut notify_off_multiplier = 0u32;
+    let mut _isr = None;
+    let mut device = None;
+
+    // PCI capability pointer is at offset 0x34
+    let mut cap_offset = ecam.read_u8(dev.bus, dev.dev, dev.func, 0x34) as u16;
+
+    while cap_offset != 0 {
+        let cap_id = ecam.read_u8(dev.bus, dev.dev, dev.func, cap_offset);
+        let cap_next = ecam.read_u8(dev.bus, dev.dev, dev.func, cap_offset + 1);
+
+        if cap_id == PCI_CAP_ID_VNDR {
+            let cfg_type = ecam.read_u8(dev.bus, dev.dev, dev.func, cap_offset + 3);
+            let bar = ecam.read_u8(dev.bus, dev.dev, dev.func, cap_offset + 4);
+            let offset = ecam.read_u32(dev.bus, dev.dev, dev.func, cap_offset + 8);
+
+            // Resolve BAR base address
+            let Some(bar_base) = read_bar_mmio64(ecam, dev, bar) else {
+                log::debug!(
+                    "virtio cap type={} bar={} - BAR not assigned",
+                    cfg_type,
+                    bar
+                );
+                cap_offset = cap_next as u16;
+                continue;
+            };
+            let region_ptr = (bar_base + offset as u64) as *mut u8;
+
+            match cfg_type {
+                VIRTIO_PCI_CAP_COMMON_CFG => common = Some(region_ptr),
+                VIRTIO_PCI_CAP_NOTIFY_CFG => {
+                    notify = Some(region_ptr);
+                    // notify_off_multiplier is at cap_offset + 16
+                    notify_off_multiplier =
+                        ecam.read_u32(dev.bus, dev.dev, dev.func, cap_offset + 16);
+                }
+                VIRTIO_PCI_CAP_ISR_CFG => _isr = Some(region_ptr),
+                VIRTIO_PCI_CAP_DEVICE_CFG => device = Some(region_ptr),
+                _ => {}
+            }
+        }
+
+        cap_offset = cap_next as u16;
+    }
+
+    Some(VirtioPciRegions {
+        common: common?,
+        notify: notify?,
+        notify_off_multiplier,
+        _isr: _isr?,
+        device: device?,
+    })
+}
+
+// Common config register offsets (from virtio_pci_common_cfg)
+const COMMON_DEVICE_FEATURE_SELECT: usize = 0;
+const COMMON_DEVICE_FEATURE: usize = 4;
+const COMMON_GUEST_FEATURE_SELECT: usize = 8;
+const COMMON_GUEST_FEATURE: usize = 12;
+#[allow(dead_code)]
+const COMMON_MSIX_CONFIG: usize = 16;
+const COMMON_NUM_QUEUES: usize = 18;
+const COMMON_DEVICE_STATUS: usize = 20;
+#[allow(dead_code)]
+const COMMON_CONFIG_GENERATION: usize = 21;
+const COMMON_QUEUE_SELECT: usize = 22;
+const COMMON_QUEUE_SIZE: usize = 24;
+const COMMON_QUEUE_MSIX_VECTOR: usize = 26;
+const COMMON_QUEUE_ENABLE: usize = 28;
+const COMMON_QUEUE_NOTIFY_OFF: usize = 30;
+const COMMON_QUEUE_DESC_LO: usize = 32;
+const COMMON_QUEUE_DESC_HI: usize = 36;
+const COMMON_QUEUE_AVAIL_LO: usize = 40;
+const COMMON_QUEUE_AVAIL_HI: usize = 44;
+const COMMON_QUEUE_USED_LO: usize = 48;
+const COMMON_QUEUE_USED_HI: usize = 52;
+
+unsafe fn mmio_read_u8(base: *mut u8, offset: usize) -> u8 {
+    unsafe { core::ptr::read_volatile(base.add(offset)) }
+}
+unsafe fn mmio_read_u16(base: *mut u8, offset: usize) -> u16 {
+    unsafe { core::ptr::read_volatile(base.add(offset) as *const u16) }
+}
+unsafe fn mmio_read_u32(base: *mut u8, offset: usize) -> u32 {
+    unsafe { core::ptr::read_volatile(base.add(offset) as *const u32) }
+}
+unsafe fn mmio_write_u8(base: *mut u8, offset: usize, val: u8) {
+    unsafe { core::ptr::write_volatile(base.add(offset), val) }
+}
+unsafe fn mmio_write_u16(base: *mut u8, offset: usize, val: u16) {
+    unsafe { core::ptr::write_volatile(base.add(offset) as *mut u16, val) }
+}
+unsafe fn mmio_write_u32(base: *mut u8, offset: usize, val: u32) {
+    unsafe { core::ptr::write_volatile(base.add(offset) as *mut u32, val) }
+}
+
+/// Virtqueue descriptor.
+#[repr(C)]
+#[derive(Clone, Copy, FromBytes, IntoBytes, Immutable, KnownLayout)]
+struct VringDesc {
+    addr: u64,
+    len: u32,
+    flags: u16,
+    next: u16,
+}
+
+/// Virtqueue available ring header.
+#[repr(C)]
+struct VringAvail {
+    flags: u16,
+    idx: u16,
+    // ring: [u16; queue_size] follows
+}
+
+/// Virtqueue used ring header.
+#[repr(C)]
+struct VringUsed {
+    flags: u16,
+    idx: u16,
+    // ring: [VringUsedElem; queue_size] follows
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct VringUsedElem {
+    id: u32,
+    len: u32,
+}
+
+/// A single virtqueue.
+pub struct VirtQueue {
+    /// Queue size (number of descriptors).
+    size: u16,
+    /// Pointer to the descriptor table.
+    desc: *mut VringDesc,
+    /// Pointer to the available ring.
+    avail: *mut VringAvail,
+    /// Pointer to the used ring.
+    used: *mut VringUsed,
+    /// Next free descriptor index.
+    free_head: u16,
+    /// Last seen used index.
+    last_used_idx: u16,
+    /// Notify address for this queue.
+    notify_addr: *mut u16,
+}
+
+impl VirtQueue {
+    /// Allocate and initialize a virtqueue.
+    fn new(size: u16, notify_addr: *mut u16) -> Self {
+        let size_usize = size as usize;
+
+        // Allocate descriptor table (16 bytes each, 16-byte aligned)
+        let desc_layout =
+            alloc::alloc::Layout::from_size_align(size_usize * size_of::<VringDesc>(), 16).unwrap();
+        let desc = unsafe { alloc::alloc::alloc_zeroed(desc_layout) as *mut VringDesc };
+
+        // Allocate available ring (4 bytes header + 2 bytes per entry, 2-byte aligned)
+        let avail_size = 4 + size_usize * 2;
+        let avail_layout = alloc::alloc::Layout::from_size_align(avail_size, 2).unwrap();
+        let avail = unsafe { alloc::alloc::alloc_zeroed(avail_layout) as *mut VringAvail };
+
+        // Allocate used ring (4 bytes header + 8 bytes per entry, 4-byte aligned)
+        let used_size = 4 + size_usize * 8;
+        let used_layout = alloc::alloc::Layout::from_size_align(used_size, 4).unwrap();
+        let used = unsafe { alloc::alloc::alloc_zeroed(used_layout) as *mut VringUsed };
+
+        // Chain free descriptors
+        for i in 0..size {
+            let d = unsafe { &mut *desc.add(i as usize) };
+            d.next = if i + 1 < size { i + 1 } else { 0 };
+        }
+
+        Self {
+            size,
+            desc,
+            avail,
+            used,
+            free_head: 0,
+            last_used_idx: 0,
+            notify_addr,
+        }
+    }
+
+    /// Allocate a descriptor chain for a request.
+    /// Returns the head descriptor index.
+    fn alloc_desc(&mut self) -> u16 {
+        let idx = self.free_head;
+        let d = unsafe { &*self.desc.add(idx as usize) };
+        self.free_head = d.next;
+        idx
+    }
+
+    /// Free a descriptor back to the free list.
+    fn free_desc(&mut self, idx: u16) {
+        let d = unsafe { &mut *self.desc.add(idx as usize) };
+        d.next = self.free_head;
+        d.flags = 0;
+        self.free_head = idx;
+    }
+
+    /// Submit a descriptor chain and notify the device.
+    fn submit(&mut self, head: u16) {
+        let avail = unsafe { &mut *self.avail };
+        let idx = avail.idx;
+        let ring_entry = unsafe {
+            &mut *((self.avail as *mut u8).add(4 + (idx % self.size) as usize * 2) as *mut u16)
+        };
+        *ring_entry = head;
+
+        fence(Ordering::Release);
+        avail.idx = idx.wrapping_add(1);
+        fence(Ordering::Release);
+
+        // Notify device
+        unsafe { core::ptr::write_volatile(self.notify_addr, 0) };
+    }
+
+    /// Poll for completion. Returns (descriptor head index, bytes written).
+    fn poll_used(&mut self) -> (u32, u32) {
+        loop {
+            fence(Ordering::Acquire);
+            let used = unsafe { &*self.used };
+            if used.idx != self.last_used_idx {
+                let elem = unsafe {
+                    &*((self.used as *const u8)
+                        .add(4 + (self.last_used_idx % self.size) as usize * 8)
+                        as *const VringUsedElem)
+                };
+                self.last_used_idx = self.last_used_idx.wrapping_add(1);
+                return (elem.id, elem.len);
+            }
+            core::hint::spin_loop();
+        }
+    }
+}
+
+/// A virtio PCI device with initialized transport.
+pub struct VirtioDevice {
+    regions: VirtioPciRegions,
+    queues: alloc::vec::Vec<VirtQueue>,
+}
+
+impl VirtioDevice {
+    /// Initialize a virtio device: reset, negotiate features, set up queues.
+    ///
+    /// PCI BARs must already be assigned and memory space / bus mastering enabled.
+    pub fn new(ecam: &Ecam, pci_dev: &PciDevice, driver_features: u64) -> Option<Self> {
+        let regions = find_virtio_pci_regions(ecam, pci_dev)?;
+        log::debug!(
+            "virtio: common={:#x} notify={:#x} device={:#x}",
+            regions.common as u64,
+            regions.notify as u64,
+            regions.device as u64
+        );
+        let common = regions.common;
+
+        // Reset device
+        unsafe { mmio_write_u8(common, COMMON_DEVICE_STATUS, 0) };
+        // Acknowledge
+        unsafe { mmio_write_u8(common, COMMON_DEVICE_STATUS, VIRTIO_STATUS_ACKNOWLEDGE) };
+        // Driver
+        unsafe {
+            mmio_write_u8(
+                common,
+                COMMON_DEVICE_STATUS,
+                VIRTIO_STATUS_ACKNOWLEDGE | VIRTIO_STATUS_DRIVER,
+            )
+        };
+
+        // Read device features
+        unsafe { mmio_write_u32(common, COMMON_DEVICE_FEATURE_SELECT, 0) };
+        let feat_lo = unsafe { mmio_read_u32(common, COMMON_DEVICE_FEATURE) } as u64;
+        unsafe { mmio_write_u32(common, COMMON_DEVICE_FEATURE_SELECT, 1) };
+        let feat_hi = unsafe { mmio_read_u32(common, COMMON_DEVICE_FEATURE) } as u64;
+        let device_features = feat_lo | (feat_hi << 32);
+
+        // Negotiate features (must include VIRTIO_F_VERSION_1 for modern)
+        let features = (driver_features | VIRTIO_F_VERSION_1) & device_features;
+
+        unsafe { mmio_write_u32(common, COMMON_GUEST_FEATURE_SELECT, 0) };
+        unsafe { mmio_write_u32(common, COMMON_GUEST_FEATURE, features as u32) };
+        unsafe { mmio_write_u32(common, COMMON_GUEST_FEATURE_SELECT, 1) };
+        unsafe { mmio_write_u32(common, COMMON_GUEST_FEATURE, (features >> 32) as u32) };
+
+        // Features OK
+        unsafe {
+            mmio_write_u8(
+                common,
+                COMMON_DEVICE_STATUS,
+                VIRTIO_STATUS_ACKNOWLEDGE | VIRTIO_STATUS_DRIVER | VIRTIO_STATUS_FEATURES_OK,
+            )
+        };
+        let status = unsafe { mmio_read_u8(common, COMMON_DEVICE_STATUS) };
+        if status & VIRTIO_STATUS_FEATURES_OK == 0 {
+            log::debug!("virtio: features rejected (status={:#x})", status);
+            return None;
+        }
+        log::debug!(
+            "virtio: features OK, device={:#x}, negotiated={:#x}",
+            device_features,
+            features
+        );
+
+        // Set up queues
+        let num_queues = unsafe { mmio_read_u16(common, COMMON_NUM_QUEUES) };
+        let mut queues = alloc::vec::Vec::with_capacity(num_queues as usize);
+
+        for i in 0..num_queues {
+            unsafe { mmio_write_u16(common, COMMON_QUEUE_SELECT, i) };
+            let queue_size = unsafe { mmio_read_u16(common, COMMON_QUEUE_SIZE) };
+            if queue_size == 0 {
+                continue;
+            }
+
+            let notify_off = unsafe { mmio_read_u16(common, COMMON_QUEUE_NOTIFY_OFF) };
+            let notify_addr = unsafe {
+                regions
+                    .notify
+                    .add(notify_off as usize * regions.notify_off_multiplier as usize)
+            } as *mut u16;
+
+            let vq = VirtQueue::new(queue_size, notify_addr);
+
+            // Tell device about queue memory locations
+            let desc_addr = vq.desc as u64;
+            let avail_addr = vq.avail as u64;
+            let used_addr = vq.used as u64;
+
+            unsafe {
+                mmio_write_u32(common, COMMON_QUEUE_DESC_LO, desc_addr as u32);
+                mmio_write_u32(common, COMMON_QUEUE_DESC_HI, (desc_addr >> 32) as u32);
+                mmio_write_u32(common, COMMON_QUEUE_AVAIL_LO, avail_addr as u32);
+                mmio_write_u32(common, COMMON_QUEUE_AVAIL_HI, (avail_addr >> 32) as u32);
+                mmio_write_u32(common, COMMON_QUEUE_USED_LO, used_addr as u32);
+                mmio_write_u32(common, COMMON_QUEUE_USED_HI, (used_addr >> 32) as u32);
+
+                // Disable MSI-X for this queue
+                mmio_write_u16(common, COMMON_QUEUE_MSIX_VECTOR, 0xFFFF);
+
+                // Enable queue
+                mmio_write_u16(common, COMMON_QUEUE_ENABLE, 1);
+            }
+
+            queues.push(vq);
+        }
+
+        // Driver OK
+        unsafe {
+            mmio_write_u8(
+                common,
+                COMMON_DEVICE_STATUS,
+                VIRTIO_STATUS_ACKNOWLEDGE
+                    | VIRTIO_STATUS_DRIVER
+                    | VIRTIO_STATUS_FEATURES_OK
+                    | VIRTIO_STATUS_DRIVER_OK,
+            )
+        };
+
+        Some(Self { regions, queues })
+    }
+
+    /// Get a mutable reference to a virtqueue.
+    pub fn queue_mut(&mut self, index: usize) -> &mut VirtQueue {
+        &mut self.queues[index]
+    }
+
+    /// Read from the device-specific config region.
+    ///
+    /// # Safety
+    /// The offset and type must match the device's config layout.
+    pub unsafe fn read_device_config<T: FromBytes>(&self, offset: usize) -> T {
+        let ptr = unsafe { self.regions.device.add(offset) };
+        let bytes = unsafe { core::slice::from_raw_parts(ptr, size_of::<T>()) };
+        T::read_from_prefix(bytes).unwrap().0
+    }
+}

--- a/lace-drivers/src/x86/mod.rs
+++ b/lace-drivers/src/x86/mod.rs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+// Copyright (C) 2026, Canonical Ltd.
+// Authors: Mate Kukri <mate.kukri@canonical.com>
+
+//! x86-specific hardware access
+
+pub mod pci_legacy;
+pub mod port_io;
+pub mod uart8250;

--- a/lace-drivers/src/x86/pci_legacy.rs
+++ b/lace-drivers/src/x86/pci_legacy.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+// Copyright (C) 2026, Canonical Ltd.
+// Authors: Mate Kukri <mate.kukri@canonical.com>
+
+//! x86 legacy PCI config space access (0xCF8/0xCFC)
+//!
+//! Only used for chipset bootstrap (e.g., enabling Q35 PCIEXBAR).
+
+use super::port_io;
+
+const CONFIG_ADDRESS: u16 = 0xCF8;
+const CONFIG_DATA: u16 = 0xCFC;
+
+fn config_addr(bus: u8, dev: u8, func: u8, offset: u8) -> u32 {
+    0x8000_0000
+        | ((bus as u32) << 16)
+        | ((dev as u32) << 11)
+        | ((func as u32) << 8)
+        | ((offset as u32) & 0xFC)
+}
+
+/// Read a 32-bit value from PCI config space.
+///
+/// # Safety
+/// The caller must ensure the BDF and offset are valid.
+pub unsafe fn read_u32(bus: u8, dev: u8, func: u8, offset: u8) -> u32 {
+    unsafe {
+        port_io::outl(CONFIG_ADDRESS, config_addr(bus, dev, func, offset));
+        port_io::inl(CONFIG_DATA)
+    }
+}
+
+/// Write a 32-bit value to PCI config space.
+///
+/// # Safety
+/// The caller must ensure the BDF and offset are valid.
+pub unsafe fn write_u32(bus: u8, dev: u8, func: u8, offset: u8, value: u32) {
+    unsafe {
+        port_io::outl(CONFIG_ADDRESS, config_addr(bus, dev, func, offset));
+        port_io::outl(CONFIG_DATA, value);
+    }
+}

--- a/lace-drivers/src/x86/port_io.rs
+++ b/lace-drivers/src/x86/port_io.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+
+//! AMD64 port based I/O wrapper routines
+
+use core::arch::asm;
+
+/// Read a byte from the given port.
+///
+/// # Safety
+/// The caller must ensure the port corresponds to a valid device.
+pub unsafe fn inb(port: u16) -> u8 {
+    let value: u8;
+    unsafe {
+        asm!("in al, dx", in("dx") port, out("al") value);
+    }
+    value
+}
+
+/// Write a byte to the given port.
+///
+/// # Safety
+/// The caller must ensure the port corresponds to a valid device.
+pub unsafe fn outb(port: u16, value: u8) {
+    unsafe {
+        asm!("out dx, al", in("dx") port, in("al") value);
+    }
+}
+
+/// Read a word from the given port.
+///
+/// # Safety
+/// The caller must ensure the port corresponds to a valid device.
+pub unsafe fn inw(port: u16) -> u16 {
+    let value: u16;
+    unsafe {
+        asm!("in ax, dx", in("dx") port, out("ax") value);
+    }
+    value
+}
+
+/// Write a word to the given port.
+///
+/// # Safety
+/// The caller must ensure the port corresponds to a valid device.
+pub unsafe fn outw(port: u16, value: u16) {
+    unsafe {
+        asm!("out dx, ax", in("dx") port, in("ax") value);
+    }
+}
+
+/// Read a double word from the given port.
+///
+/// # Safety
+/// The caller must ensure the port corresponds to a valid device.
+pub unsafe fn inl(port: u16) -> u32 {
+    let value: u32;
+    unsafe {
+        asm!("in eax, dx", in("dx") port, out("eax") value);
+    }
+    value
+}
+
+/// Write a double word to the given port.
+///
+/// # Safety
+/// The caller must ensure the port corresponds to a valid device.
+pub unsafe fn outl(port: u16, value: u32) {
+    unsafe {
+        asm!("out dx, eax", in("dx") port, in("eax") value);
+    }
+}
+
+/// I/O wait by writing to port 0x80.
+///
+/// # Safety
+/// This writes to the debug port which is safe on standard x86 platforms.
+pub unsafe fn io_wait() {
+    unsafe {
+        asm!("out 0x80, al", in("al") 0u8);
+    }
+}

--- a/lace-drivers/src/x86/uart8250.rs
+++ b/lace-drivers/src/x86/uart8250.rs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+// Copyright (C) 2026, Canonical Ltd.
+// Authors: Mate Kukri <mate.kukri@canonical.com>
+
+//! 8250/16550 UART driver using x86 port I/O
+
+use super::port_io;
+use core::fmt;
+
+// Register offsets
+const DATA: u16 = 0; // Data register
+const IER: u16 = 1; // Interrupt enable register
+const FCR: u16 = 2; // FIFO control register
+const LCR: u16 = 3; // Line control register
+const MCR: u16 = 4; // Modem control register
+const LSR: u16 = 5; // Line status register
+
+// Register offsets when DLAB (Divisor Latch Access Bit) is set
+const DLL: u16 = 0; // Divisor latch low byte
+const DLH: u16 = 1; // Divisor latch high byte
+
+// Line status register bits
+const LSR_DATA_READY: u8 = 0x01;
+const LSR_TX_EMPTY: u8 = 0x20;
+
+// Line control register bits
+const LCR_8N1: u8 = 0x03; // 8 data bits, no parity, 1 stop bit
+const LCR_DLAB: u8 = 0x80; // Divisor latch access bit
+
+// UART clock and baud rate
+const UART_CLOCK_HZ: u32 = 1_843_200;
+const BAUD_RATE: u32 = 115_200;
+const DIVISOR: u16 = (UART_CLOCK_HZ / (BAUD_RATE * 16)) as u16;
+
+pub struct Uart8250 {
+    base_port: u16,
+}
+
+impl Uart8250 {
+    /// Create a new Uart8250 instance at the given base port.
+    ///
+    /// # Safety
+    /// The caller must ensure that the given port actually corresponds to a UART8250 device.
+    pub const unsafe fn new(base_port: u16) -> Self {
+        Self { base_port }
+    }
+
+    /// Initialize the UART: disable interrupts, set 115200 baud 8N1, enable FIFO.
+    pub fn init(&mut self) {
+        unsafe {
+            // Disable all interrupts
+            port_io::outb(self.base_port + IER, 0x00);
+
+            // Enable DLAB to set baud rate divisor
+            port_io::outb(self.base_port + LCR, LCR_DLAB);
+
+            // Set divisor for 115200 baud
+            port_io::outb(self.base_port + DLL, DIVISOR as u8);
+            port_io::outb(self.base_port + DLH, (DIVISOR >> 8) as u8);
+
+            // 8 data bits, no parity, 1 stop bit (clears DLAB)
+            port_io::outb(self.base_port + LCR, LCR_8N1);
+
+            // Enable FIFO, clear TX/RX, 14-byte threshold
+            port_io::outb(self.base_port + FCR, 0xC7);
+
+            // Set RTS/DTR
+            port_io::outb(self.base_port + MCR, 0x03);
+        }
+    }
+
+    /// Read a byte from the UART (blocking).
+    pub fn read_byte(&mut self) -> u8 {
+        while (unsafe { port_io::inb(self.base_port + LSR) } & LSR_DATA_READY) == 0 {
+            core::hint::spin_loop();
+        }
+        unsafe { port_io::inb(self.base_port + DATA) }
+    }
+
+    /// Write a byte to the UART (blocking).
+    pub fn write_byte(&mut self, byte: u8) {
+        while (unsafe { port_io::inb(self.base_port + LSR) } & LSR_TX_EMPTY) == 0 {
+            core::hint::spin_loop();
+        }
+        unsafe { port_io::outb(self.base_port + DATA, byte) };
+    }
+}
+
+impl fmt::Write for Uart8250 {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        for byte in s.bytes() {
+            if byte == b'\n' {
+                self.write_byte(b'\r');
+            }
+            self.write_byte(byte);
+        }
+        Ok(())
+    }
+}

--- a/lace-util/src/acpi/fadt.rs
+++ b/lace-util/src/acpi/fadt.rs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+// Copyright (C) 2026, Canonical Ltd.
+// Authors: Mate Kukri <mate.kukri@canonical.com>
+
+//! ACPI FADT (Fixed ACPI Description Table) and FACS parsing.
+
+use zerocopy::{FromBytes, Immutable, KnownLayout};
+
+/// ACPI Generic Address Structure (GAS).
+#[repr(C, packed)]
+#[derive(Clone, Copy, FromBytes, Immutable, KnownLayout)]
+pub struct Gas {
+    pub address_space_id: u8,
+    pub register_bit_width: u8,
+    pub register_bit_offset: u8,
+    pub access_size: u8,
+    pub address: u64,
+}
+
+/// ACPI FADT (Fixed ACPI Description Table), revision 3+ layout.
+#[repr(C, packed)]
+#[derive(FromBytes, Immutable, KnownLayout)]
+pub struct Fadt {
+    pub header: super::SdtHeader,
+    pub firmware_ctrl: u32,
+    pub dsdt: u32,
+    pub reserved0: u8,
+    pub preferred_pm_profile: u8,
+    pub sci_int: u16,
+    pub smi_cmd: u32,
+    pub acpi_enable: u8,
+    pub acpi_disable: u8,
+    pub s4bios_req: u8,
+    pub pstate_cnt: u8,
+    pub pm1a_evt_blk: u32,
+    pub pm1b_evt_blk: u32,
+    pub pm1a_cnt_blk: u32,
+    pub pm1b_cnt_blk: u32,
+    pub pm2_cnt_blk: u32,
+    pub pm_tmr_blk: u32,
+    pub gpe0_blk: u32,
+    pub gpe1_blk: u32,
+    pub pm1_evt_len: u8,
+    pub pm1_cnt_len: u8,
+    pub pm2_cnt_len: u8,
+    pub pm_tmr_len: u8,
+    pub gpe0_blk_len: u8,
+    pub gpe1_blk_len: u8,
+    pub gpe1_base: u8,
+    pub cst_cnt: u8,
+    pub p_lvl2_lat: u16,
+    pub p_lvl3_lat: u16,
+    pub flush_size: u16,
+    pub flush_stride: u16,
+    pub duty_offset: u8,
+    pub duty_width: u8,
+    pub day_alrm: u8,
+    pub mon_alrm: u8,
+    pub century: u8,
+    pub iapc_boot_arch: u16,
+    pub reserved1: u8,
+    pub flags: u32,
+    pub reset_reg: Gas,
+    pub reset_value: u8,
+    pub reserved2: [u8; 3],
+    pub x_firmware_ctrl: u64,
+    pub x_dsdt: u64,
+    pub x_pm1a_evt_blk: Gas,
+    pub x_pm1b_evt_blk: Gas,
+    pub x_pm1a_cnt_blk: Gas,
+    pub x_pm1b_cnt_blk: Gas,
+    pub x_pm2_cnt_blk: Gas,
+    pub x_pm_tmr_blk: Gas,
+    pub x_gpe0_blk: Gas,
+    pub x_gpe1_blk: Gas,
+}
+
+/// ACPI FACS (Firmware ACPI Control Structure).
+#[repr(C, packed)]
+#[derive(FromBytes, Immutable, KnownLayout)]
+pub struct Facs {
+    pub signature: [u8; 4],
+    pub length: u32,
+    pub hardware_signature: u32,
+    pub firmware_waking_vector: u32,
+    pub global_lock: u32,
+    pub flags: u32,
+    pub x_firmware_waking_vector: u64,
+    pub version: u8,
+}
+
+/// Extract the FACS physical address from a FADT.
+pub fn parse_fadt_facs_addr(data: &[u8]) -> Option<u64> {
+    let (fadt, _) = Fadt::ref_from_prefix(data).ok()?;
+    if &fadt.header.signature != b"FACP" {
+        return None;
+    }
+
+    // Prefer 64-bit X_FIRMWARE_CTRL if non-zero
+    let addr = if fadt.x_firmware_ctrl != 0 {
+        fadt.x_firmware_ctrl
+    } else {
+        fadt.firmware_ctrl as u64
+    };
+
+    if addr == 0 { None } else { Some(addr) }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_parse_fadt_facs_addr_32bit() {
+        let mut data = [0u8; size_of::<Fadt>()];
+        data[0..4].copy_from_slice(b"FACP");
+        data[4..8].copy_from_slice(&(size_of::<Fadt>() as u32).to_le_bytes());
+        // firmware_ctrl at offset 36
+        let facs_addr: u32 = 0xDEAD_0000;
+        data[36..40].copy_from_slice(&facs_addr.to_le_bytes());
+
+        assert_eq!(parse_fadt_facs_addr(&data), Some(0xDEAD_0000));
+    }
+
+    #[test]
+    fn test_parse_fadt_facs_addr_64bit() {
+        let mut data = [0u8; size_of::<Fadt>()];
+        data[0..4].copy_from_slice(b"FACP");
+        data[4..8].copy_from_slice(&(size_of::<Fadt>() as u32).to_le_bytes());
+        // firmware_ctrl (32-bit) at offset 36
+        data[36..40].copy_from_slice(&0x1234_0000u32.to_le_bytes());
+        // x_firmware_ctrl (64-bit)
+        let x_offset = core::mem::offset_of!(Fadt, x_firmware_ctrl);
+        data[x_offset..x_offset + 8].copy_from_slice(&0xCAFE_BABE_0000u64.to_le_bytes());
+
+        // Should prefer x_firmware_ctrl
+        assert_eq!(parse_fadt_facs_addr(&data), Some(0xCAFE_BABE_0000));
+    }
+
+    #[test]
+    fn test_parse_fadt_bad_signature() {
+        let mut data = [0u8; size_of::<Fadt>()];
+        data[0..4].copy_from_slice(b"XXXX");
+        assert_eq!(parse_fadt_facs_addr(&data), None);
+    }
+
+    #[test]
+    fn test_parse_fadt_zero_facs() {
+        let mut data = [0u8; size_of::<Fadt>()];
+        data[0..4].copy_from_slice(b"FACP");
+        data[4..8].copy_from_slice(&(size_of::<Fadt>() as u32).to_le_bytes());
+        assert_eq!(parse_fadt_facs_addr(&data), None);
+    }
+}

--- a/lace-util/src/acpi/mcfg.rs
+++ b/lace-util/src/acpi/mcfg.rs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+// Copyright (C) 2026, Canonical Ltd.
+// Authors: Mate Kukri <mate.kukri@canonical.com>
+
+//! ACPI MCFG (Memory Mapped Configuration Space) table parser
+
+use super::SdtHeader;
+use zerocopy::{FromBytes, Immutable, KnownLayout};
+
+/// MCFG allocation entry — describes one PCI segment's ECAM region.
+#[repr(C, packed)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, FromBytes, Immutable, KnownLayout)]
+pub struct McfgEntry {
+    pub base_address: u64,
+    pub segment_group: u16,
+    pub start_bus: u8,
+    pub end_bus: u8,
+    pub _reserved: u32,
+}
+
+/// Parse the MCFG table from a byte slice and return the first allocation entry.
+///
+/// The caller is responsible for producing `data` from the physical MCFG
+/// address; by taking a slice rather than a raw pointer the parsing logic is
+/// safe and unit-testable.
+pub fn parse_mcfg(data: &[u8]) -> Option<McfgEntry> {
+    let (header, _) = SdtHeader::ref_from_prefix(data).ok()?;
+    if &header.signature != b"MCFG" {
+        return None;
+    }
+
+    // 8 bytes of reserved space follow the SDT header, then the entries.
+    let entries_offset = size_of::<SdtHeader>() + 8;
+    let total_length = header.length as usize;
+    if total_length > data.len() || total_length < entries_offset + size_of::<McfgEntry>() {
+        return None;
+    }
+
+    let (entry, _) = McfgEntry::ref_from_prefix(&data[entries_offset..total_length]).ok()?;
+    Some(*entry)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn build_mcfg(entry: &McfgEntry) -> alloc::vec::Vec<u8> {
+        let sdt_hdr_size = size_of::<SdtHeader>();
+        let entries_offset = sdt_hdr_size + 8;
+        let total = entries_offset + size_of::<McfgEntry>();
+        let mut buf = alloc::vec![0u8; total];
+        buf[0..4].copy_from_slice(b"MCFG");
+        buf[4..8].copy_from_slice(&(total as u32).to_le_bytes());
+
+        let entry_bytes = &mut buf[entries_offset..total];
+        entry_bytes[0..8].copy_from_slice(&entry.base_address.to_le_bytes());
+        entry_bytes[8..10].copy_from_slice(&entry.segment_group.to_le_bytes());
+        entry_bytes[10] = entry.start_bus;
+        entry_bytes[11] = entry.end_bus;
+        buf
+    }
+
+    #[test]
+    fn test_parse_mcfg_valid() {
+        let entry = McfgEntry {
+            base_address: 0xE000_0000,
+            segment_group: 0,
+            start_bus: 0,
+            end_bus: 0xFF,
+            _reserved: 0,
+        };
+        let buf = build_mcfg(&entry);
+        let parsed = parse_mcfg(&buf).unwrap();
+        assert_eq!({ parsed.base_address }, 0xE000_0000);
+        assert_eq!({ parsed.segment_group }, 0);
+        assert_eq!(parsed.start_bus, 0);
+        assert_eq!(parsed.end_bus, 0xFF);
+    }
+
+    #[test]
+    fn test_parse_mcfg_bad_signature() {
+        let entry = McfgEntry {
+            base_address: 0,
+            segment_group: 0,
+            start_bus: 0,
+            end_bus: 0,
+            _reserved: 0,
+        };
+        let mut buf = build_mcfg(&entry);
+        buf[0..4].copy_from_slice(b"FACP");
+        assert!(parse_mcfg(&buf).is_none());
+    }
+
+    #[test]
+    fn test_parse_mcfg_truncated() {
+        let entry = McfgEntry {
+            base_address: 0,
+            segment_group: 0,
+            start_bus: 0,
+            end_bus: 0,
+            _reserved: 0,
+        };
+        let buf = build_mcfg(&entry);
+        // Drop the last byte of the entry — length field still claims full size.
+        assert!(parse_mcfg(&buf[..buf.len() - 1]).is_none());
+    }
+
+    #[test]
+    fn test_parse_mcfg_no_entries() {
+        let sdt_hdr_size = size_of::<SdtHeader>();
+        let total = sdt_hdr_size + 8; // header + reserved, no entries
+        let mut buf = alloc::vec![0u8; total];
+        buf[0..4].copy_from_slice(b"MCFG");
+        buf[4..8].copy_from_slice(&(total as u32).to_le_bytes());
+        assert!(parse_mcfg(&buf).is_none());
+    }
+}

--- a/lace-util/src/acpi/mod.rs
+++ b/lace-util/src/acpi/mod.rs
@@ -8,6 +8,7 @@
 
 use zerocopy::{FromBytes, Immutable, KnownLayout};
 
+pub mod mcfg;
 
 /// ACPI RSDP v1 (revision 0), 20 bytes.
 #[repr(C, packed)]

--- a/lace-util/src/acpi/mod.rs
+++ b/lace-util/src/acpi/mod.rs
@@ -8,6 +8,7 @@
 
 use zerocopy::{FromBytes, Immutable, KnownLayout};
 
+pub mod fadt;
 pub mod mcfg;
 
 /// ACPI RSDP v1 (revision 0), 20 bytes.

--- a/lace-util/src/acpi/mod.rs
+++ b/lace-util/src/acpi/mod.rs
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+// Copyright (C) 2026, Canonical Ltd.
+// Authors: Mate Kukri <mate.kukri@canonical.com>
+
+//! Minimal ACPI table parser
+//!
+//! Parses RSDP, XSDT/RSDT, and locates tables by signature.
+
+use zerocopy::{FromBytes, Immutable, KnownLayout};
+
+
+/// ACPI RSDP v1 (revision 0), 20 bytes.
+#[repr(C, packed)]
+#[derive(FromBytes, Immutable, KnownLayout)]
+pub struct RsdpV1 {
+    pub signature: [u8; 8],
+    pub checksum: u8,
+    pub oem_id: [u8; 6],
+    pub revision: u8,
+    pub rsdt_address: u32,
+}
+
+/// ACPI RSDP v2 extension (revision >= 2), 36 bytes total.
+#[repr(C, packed)]
+#[derive(FromBytes, Immutable, KnownLayout)]
+pub struct RsdpV2 {
+    pub v1: RsdpV1,
+    pub length: u32,
+    pub xsdt_address: u64,
+    pub extended_checksum: u8,
+    pub _reserved: [u8; 3],
+}
+
+/// ACPI System Description Table header (common to all ACPI tables).
+#[repr(C, packed)]
+#[derive(FromBytes, Immutable, KnownLayout)]
+pub struct SdtHeader {
+    pub signature: [u8; 4],
+    pub length: u32,
+    pub revision: u8,
+    pub checksum: u8,
+    pub oem_id: [u8; 6],
+    pub oem_table_id: [u8; 8],
+    pub oem_revision: u32,
+    pub creator_id: u32,
+    pub creator_revision: u32,
+}
+
+/// Parsed RSDP — provides access to either RSDT (v1) or XSDT (v2) address.
+pub struct Rsdp {
+    pub revision: u8,
+    pub rsdt_address: u32,
+    pub xsdt_address: u64, // 0 if revision < 2
+}
+
+impl Rsdp {
+    /// Parse the RSDP from a byte slice.
+    pub fn parse(data: &[u8]) -> Option<Self> {
+        let (v1, _) = RsdpV1::ref_from_prefix(data).ok()?;
+        if &v1.signature != b"RSD PTR " {
+            return None;
+        }
+
+        let revision = v1.revision;
+        let rsdt_address = v1.rsdt_address;
+
+        let xsdt_address = if revision >= 2 {
+            if let Ok((v2, _)) = RsdpV2::ref_from_prefix(data) {
+                v2.xsdt_address
+            } else {
+                0
+            }
+        } else {
+            0
+        };
+
+        Some(Self {
+            revision,
+            rsdt_address,
+            xsdt_address,
+        })
+    }
+
+    /// Find a table by signature in the XSDT or RSDT.
+    ///
+    /// `deref` resolves a physical address and length to a byte slice.
+    /// This is the only part that requires unsafe on bare metal (the caller
+    /// provides it), keeping the search logic itself safe and testable.
+    pub fn find_table<'a>(
+        &self,
+        signature: &[u8; 4],
+        deref: impl Fn(u64, usize) -> &'a [u8],
+    ) -> Option<u64> {
+        let (sdt_addr, ptr_size) = if self.revision >= 2 && self.xsdt_address != 0 {
+            (self.xsdt_address, 8)
+        } else {
+            (self.rsdt_address as u64, 4)
+        };
+
+        // Read the SDT header to get the total length
+        let header_bytes = deref(sdt_addr, size_of::<SdtHeader>());
+        let (header, _) = SdtHeader::ref_from_prefix(header_bytes).ok()?;
+        let total_length = header.length as usize;
+
+        // Read the full SDT
+        let sdt_data = deref(sdt_addr, total_length);
+
+        // Walk entries
+        let entries_offset = size_of::<SdtHeader>();
+        let entries_len = total_length.checked_sub(entries_offset)?;
+        let num_entries = entries_len / ptr_size;
+
+        for i in 0..num_entries {
+            let off = entries_offset + i * ptr_size;
+            if off + ptr_size > sdt_data.len() {
+                break;
+            }
+            let addr = if ptr_size == 8 {
+                u64::from_le_bytes(sdt_data[off..off + 8].try_into().ok()?)
+            } else {
+                u32::from_le_bytes(sdt_data[off..off + 4].try_into().ok()?) as u64
+            };
+
+            // Read the table's signature
+            let table_header = deref(addr, 4);
+            if table_header == signature {
+                return Some(addr);
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_parse_rsdp_v1() {
+        let mut data = [0u8; 20];
+        data[0..8].copy_from_slice(b"RSD PTR ");
+        data[15] = 0; // revision 0
+        data[16..20].copy_from_slice(&0x12345678u32.to_le_bytes());
+
+        let rsdp = Rsdp::parse(&data).unwrap();
+        assert_eq!(rsdp.revision, 0);
+        assert_eq!(rsdp.rsdt_address, 0x12345678);
+        assert_eq!(rsdp.xsdt_address, 0);
+    }
+
+    #[test]
+    fn test_parse_rsdp_v2() {
+        let mut data = [0u8; 36];
+        data[0..8].copy_from_slice(b"RSD PTR ");
+        data[15] = 2; // revision 2
+        data[16..20].copy_from_slice(&0xAABBCCDDu32.to_le_bytes());
+        data[20..24].copy_from_slice(&36u32.to_le_bytes());
+        data[24..32].copy_from_slice(&0xDEADBEEF_CAFEBABEu64.to_le_bytes());
+
+        let rsdp = Rsdp::parse(&data).unwrap();
+        assert_eq!(rsdp.revision, 2);
+        assert_eq!(rsdp.rsdt_address, 0xAABBCCDD);
+        assert_eq!(rsdp.xsdt_address, 0xDEADBEEF_CAFEBABE);
+    }
+
+    #[test]
+    fn test_parse_rsdp_bad_signature() {
+        let mut data = [0u8; 20];
+        data[0..8].copy_from_slice(b"NOT RSDP");
+        assert!(Rsdp::parse(&data).is_none());
+    }
+
+    #[test]
+    fn test_parse_rsdp_too_small() {
+        assert!(Rsdp::parse(&[0u8; 10]).is_none());
+    }
+
+    #[test]
+    fn test_find_table_xsdt() {
+        let sdt_hdr_size = size_of::<SdtHeader>();
+
+        // Place the XSDT at a non-zero offset so the revision>=2 &&
+        // xsdt_address!=0 branch is taken (rather than falling back to RSDT).
+        let xsdt_base = 0x100usize;
+        let xsdt_entries = 2;
+        let xsdt_len = sdt_hdr_size + xsdt_entries * 8;
+        let facp_off = xsdt_base + xsdt_len;
+        let mcfg_off = facp_off + sdt_hdr_size;
+        let total = mcfg_off + sdt_hdr_size;
+
+        let mut buf = alloc::vec![0u8; total];
+
+        // XSDT header
+        buf[xsdt_base..xsdt_base + 4].copy_from_slice(b"XSDT");
+        buf[xsdt_base + 4..xsdt_base + 8].copy_from_slice(&(xsdt_len as u32).to_le_bytes());
+
+        // FACP and MCFG table headers
+        buf[facp_off..facp_off + 4].copy_from_slice(b"FACP");
+        buf[mcfg_off..mcfg_off + 4].copy_from_slice(b"MCFG");
+
+        // 8-byte XSDT entries
+        let e0 = xsdt_base + sdt_hdr_size;
+        buf[e0..e0 + 8].copy_from_slice(&(facp_off as u64).to_le_bytes());
+        buf[e0 + 8..e0 + 16].copy_from_slice(&(mcfg_off as u64).to_le_bytes());
+
+        let rsdp = Rsdp {
+            revision: 2,
+            rsdt_address: 0,
+            xsdt_address: xsdt_base as u64,
+        };
+
+        // deref treats addresses as offsets into buf
+        let deref = |addr: u64, len: usize| &buf[addr as usize..addr as usize + len];
+
+        assert_eq!(rsdp.find_table(b"MCFG", &deref), Some(mcfg_off as u64));
+        assert_eq!(rsdp.find_table(b"FACP", &deref), Some(facp_off as u64));
+        assert_eq!(rsdp.find_table(b"HPET", &deref), None);
+    }
+
+    #[test]
+    fn test_find_table_rsdt() {
+        let sdt_hdr_size = size_of::<SdtHeader>();
+
+        // Build RSDT with 2 entries (32-bit pointers)
+        let rsdt_entries = 2;
+        let rsdt_len = sdt_hdr_size + rsdt_entries * 4;
+        let facp_off = rsdt_len;
+        let apic_off = facp_off + sdt_hdr_size;
+        let total = apic_off + sdt_hdr_size;
+
+        let mut buf = alloc::vec![0u8; total];
+
+        buf[0..4].copy_from_slice(b"RSDT");
+        buf[4..8].copy_from_slice(&(rsdt_len as u32).to_le_bytes());
+
+        buf[facp_off..facp_off + 4].copy_from_slice(b"FACP");
+        buf[apic_off..apic_off + 4].copy_from_slice(b"APIC");
+
+        buf[sdt_hdr_size..sdt_hdr_size + 4].copy_from_slice(&(facp_off as u32).to_le_bytes());
+        buf[sdt_hdr_size + 4..sdt_hdr_size + 8].copy_from_slice(&(apic_off as u32).to_le_bytes());
+
+        let rsdp = Rsdp {
+            revision: 0,
+            rsdt_address: 0,
+            xsdt_address: 0,
+        };
+
+        let deref = |addr: u64, len: usize| &buf[addr as usize..addr as usize + len];
+
+        assert_eq!(rsdp.find_table(b"APIC", &deref), Some(apic_off as u64));
+        assert_eq!(rsdp.find_table(b"FACP", &deref), Some(facp_off as u64));
+        assert_eq!(rsdp.find_table(b"MCFG", &deref), None);
+    }
+}

--- a/lace-util/src/cbfs.rs
+++ b/lace-util/src/cbfs.rs
@@ -1,0 +1,340 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+// Copyright (C) 2026, Canonical Ltd.
+// Authors: Mate Kukri <mate.kukri@canonical.com>
+
+//! CBFS (coreboot filesystem) structures and parser
+//!
+//! Provides both the on-flash data structures (for reading and writing CBFS
+//! images) and a read-only parser for memory-mapped flash.
+
+use zerocopy::byteorder::{BE, U32};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+
+// Public constants for CBFS format
+
+/// CBFS header magic: 'ORBC' in big-endian.
+pub const CBFS_HEADER_MAGIC: u32 = 0x4F524243;
+/// CBFS header version 2: '1112' in big-endian.
+pub const CBFS_HEADER_VERSION2: u32 = 0x31313132;
+/// CBFS file magic: "LARCHIVE".
+pub const CBFS_FILE_MAGIC: [u8; 8] = *b"LARCHIVE";
+/// CBFS alignment (fixed to 64 bytes).
+pub const CBFS_ALIGNMENT: usize = 64;
+/// CBFS architecture: x86.
+pub const CBFS_ARCHITECTURE_X86: u32 = 0x00000001;
+
+// File types
+pub const CBFS_TYPE_DELETED: u32 = 0x00000000;
+pub const CBFS_TYPE_NULL: u32 = 0xFFFFFFFF;
+pub const CBFS_TYPE_BOOTBLOCK: u32 = 0x01;
+pub const CBFS_TYPE_RAW: u32 = 0x50;
+
+/// CBFS master header (on-flash format, all big-endian).
+#[repr(C)]
+#[derive(Clone, FromBytes, IntoBytes, Immutable, KnownLayout)]
+pub struct CbfsHeader {
+    pub magic: U32<BE>,
+    pub version: U32<BE>,
+    pub romsize: U32<BE>,
+    pub bootblocksize: U32<BE>,
+    pub align: U32<BE>,
+    pub offset: U32<BE>,
+    pub architecture: U32<BE>,
+    pub _pad: U32<BE>,
+}
+
+/// CBFS file entry header (on-flash format, all big-endian).
+#[repr(C)]
+#[derive(Clone, FromBytes, IntoBytes, Immutable, KnownLayout)]
+pub struct CbfsFileHeader {
+    pub magic: [u8; 8],
+    pub len: U32<BE>,
+    pub type_: U32<BE>,
+    pub attributes_offset: U32<BE>,
+    pub offset: U32<BE>,
+}
+
+/// Size of the file header in bytes.
+pub const CBFS_FILE_HEADER_SIZE: usize = size_of::<CbfsFileHeader>();
+
+/// Calculate total header size (fixed header + filename + null + padding to alignment).
+pub fn cbfs_file_header_total_size(name: &str) -> usize {
+    cbfs_align_up(CBFS_FILE_HEADER_SIZE + name.len() + 1)
+}
+
+/// Align a value up to CBFS alignment.
+pub fn cbfs_align_up(value: usize) -> usize {
+    (value + CBFS_ALIGNMENT - 1) & !(CBFS_ALIGNMENT - 1)
+}
+
+// --- Read-only parser for memory-mapped flash ---
+
+/// A file found in a CBFS image.
+pub struct CbfsFile<'a> {
+    pub name: &'a str,
+    pub data: &'a [u8],
+    pub type_: u32,
+}
+
+/// A parsed CBFS image backed by a memory-mapped ROM region.
+pub struct Cbfs<'a> {
+    rom: &'a [u8],
+    entries_offset: usize,
+    bootblock_size: usize,
+}
+
+impl<'a> Cbfs<'a> {
+    /// Parse a CBFS image from a memory-mapped ROM slice.
+    ///
+    /// `rom_base` is the absolute address where the ROM is mapped (e.g.
+    /// `0xFFC00000` for a 4MB ROM). This is needed to resolve the header
+    /// pointer at the last 4 bytes of the ROM, which stores an absolute address.
+    pub fn parse(rom: &'a [u8], rom_base: u32) -> Option<Self> {
+        if rom.len() < 4 {
+            return None;
+        }
+
+        // Read header pointer from last 4 bytes of ROM (little-endian absolute address)
+        let ptr_bytes: [u8; 4] = rom[rom.len() - 4..].try_into().ok()?;
+        let header_addr = u32::from_le_bytes(ptr_bytes);
+        let header_offset = header_addr.checked_sub(rom_base)? as usize;
+
+        if header_offset + size_of::<CbfsHeader>() > rom.len() {
+            return None;
+        }
+
+        let (header, _) = CbfsHeader::read_from_prefix(&rom[header_offset..]).ok()?;
+        if header.magic.get() != CBFS_HEADER_MAGIC {
+            return None;
+        }
+
+        let bootblock_size = header.bootblocksize.get() as usize;
+        if bootblock_size > rom.len() {
+            return None;
+        }
+
+        Some(Self {
+            rom,
+            entries_offset: header.offset.get() as usize,
+            bootblock_size,
+        })
+    }
+
+    /// Iterate over all files, calling `f` for each.
+    ///
+    /// The callback returns `true` to continue, `false` to stop.
+    pub fn for_each_file(&self, mut f: impl FnMut(&CbfsFile<'a>) -> bool) {
+        let end = self.rom.len() - self.bootblock_size;
+        let mut cursor = self.entries_offset;
+
+        while cursor + CBFS_FILE_HEADER_SIZE <= end {
+            let Some((hdr, _)) = CbfsFileHeader::read_from_prefix(&self.rom[cursor..]).ok() else {
+                break;
+            };
+
+            if hdr.magic != CBFS_FILE_MAGIC {
+                break;
+            }
+
+            let type_ = hdr.type_.get();
+            if type_ == CBFS_TYPE_DELETED {
+                break;
+            }
+
+            let data_offset = hdr.offset.get() as usize;
+            let data_len = hdr.len.get() as usize;
+            let data_start = cursor + data_offset;
+
+            if data_start + data_len > end {
+                break;
+            }
+
+            // Advance cursor to next aligned entry
+            let entry_size = cbfs_align_up(data_offset + data_len);
+            let next_cursor = cursor + entry_size;
+
+            // Skip null/empty entries
+            if type_ != CBFS_TYPE_NULL {
+                // Extract null-terminated filename
+                let name_start = cursor + CBFS_FILE_HEADER_SIZE;
+                let name_bytes = &self.rom[name_start..cursor + data_offset];
+                let name_len = name_bytes
+                    .iter()
+                    .position(|&b| b == 0)
+                    .unwrap_or(name_bytes.len());
+                let name = core::str::from_utf8(&name_bytes[..name_len]).unwrap_or("");
+
+                let file = CbfsFile {
+                    name,
+                    data: &self.rom[data_start..data_start + data_len],
+                    type_,
+                };
+                if !f(&file) {
+                    return;
+                }
+            }
+
+            cursor = next_cursor;
+        }
+    }
+
+    /// Get the bootblock size.
+    pub fn bootblock_size(&self) -> usize {
+        self.bootblock_size
+    }
+
+    /// Find a file by name.
+    pub fn find_file(&self, name: &str) -> Option<CbfsFile<'a>> {
+        let mut result = None;
+        self.for_each_file(|file| {
+            if file.name == name {
+                result = Some(CbfsFile {
+                    name: file.name,
+                    data: file.data,
+                    type_: file.type_,
+                });
+                false
+            } else {
+                true
+            }
+        });
+        result
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use zerocopy::IntoBytes;
+    use zerocopy::byteorder::U32;
+
+    const ROM_SIZE: usize = 4096;
+    const BB_SIZE: usize = 256;
+    const ROM_BASE: u32 = 0xFFFF_F000; // 4GB - ROM_SIZE
+
+    /// Build a minimal CBFS ROM image with the given files.
+    fn build_test_rom(files: &[(&str, u32, &[u8])]) -> Vec<u8> {
+        let mut rom = vec![0xFFu8; ROM_SIZE];
+        let mut cursor = 0usize;
+
+        // Write master header as first file
+        let header = CbfsHeader {
+            magic: U32::new(CBFS_HEADER_MAGIC),
+            version: U32::new(CBFS_HEADER_VERSION2),
+            romsize: U32::new(ROM_SIZE as u32),
+            bootblocksize: U32::new(BB_SIZE as u32),
+            align: U32::new(CBFS_ALIGNMENT as u32),
+            offset: U32::new(0),
+            architecture: U32::new(CBFS_ARCHITECTURE_X86),
+            _pad: U32::new(0),
+        };
+        let hdr_name = "cbfs_master_header";
+        let hdr_total = cbfs_file_header_total_size(hdr_name);
+        let hdr_data = header.as_bytes();
+        let entry_size = cbfs_align_up(hdr_total + hdr_data.len());
+        let file_hdr = CbfsFileHeader {
+            magic: CBFS_FILE_MAGIC,
+            len: U32::new(hdr_data.len() as u32),
+            type_: U32::new(CBFS_TYPE_RAW),
+            attributes_offset: U32::new(0),
+            offset: U32::new(hdr_total as u32),
+        };
+        // Zero the entry area for null termination
+        rom[cursor..cursor + entry_size].fill(0);
+        rom[cursor..cursor + CBFS_FILE_HEADER_SIZE].copy_from_slice(file_hdr.as_bytes());
+        rom[cursor + CBFS_FILE_HEADER_SIZE..cursor + CBFS_FILE_HEADER_SIZE + hdr_name.len()]
+            .copy_from_slice(hdr_name.as_bytes());
+        rom[cursor + hdr_total..cursor + hdr_total + hdr_data.len()].copy_from_slice(hdr_data);
+        let header_data_offset = cursor + hdr_total;
+        cursor += entry_size;
+
+        // Write user files
+        for &(name, type_, data) in files {
+            let total = cbfs_file_header_total_size(name);
+            let entry_len = cbfs_align_up(total + data.len());
+            let fh = CbfsFileHeader {
+                magic: CBFS_FILE_MAGIC,
+                len: U32::new(data.len() as u32),
+                type_: U32::new(type_),
+                attributes_offset: U32::new(0),
+                offset: U32::new(total as u32),
+            };
+            rom[cursor..cursor + entry_len].fill(0);
+            rom[cursor..cursor + CBFS_FILE_HEADER_SIZE].copy_from_slice(fh.as_bytes());
+            rom[cursor + CBFS_FILE_HEADER_SIZE..cursor + CBFS_FILE_HEADER_SIZE + name.len()]
+                .copy_from_slice(name.as_bytes());
+            rom[cursor + total..cursor + total + data.len()].copy_from_slice(data);
+            cursor += cbfs_align_up(total + data.len());
+        }
+
+        // Write header pointer at last 4 bytes
+        let header_addr = ROM_BASE + header_data_offset as u32;
+        rom[ROM_SIZE - 4..ROM_SIZE].copy_from_slice(&header_addr.to_le_bytes());
+
+        rom
+    }
+
+    #[test]
+    fn test_parse_empty_cbfs() {
+        let rom = build_test_rom(&[]);
+        let cbfs = Cbfs::parse(&rom, ROM_BASE).unwrap();
+        assert_eq!(cbfs.bootblock_size(), BB_SIZE);
+
+        let mut count = 0;
+        cbfs.for_each_file(|_| {
+            count += 1;
+            true
+        });
+        // Only the master header file
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_find_file() {
+        let rom = build_test_rom(&[("test/hello", CBFS_TYPE_RAW, b"Hello CBFS!")]);
+        let cbfs = Cbfs::parse(&rom, ROM_BASE).unwrap();
+
+        let file = cbfs.find_file("test/hello").unwrap();
+        assert_eq!(file.name, "test/hello");
+        assert_eq!(file.data, b"Hello CBFS!");
+        assert_eq!(file.type_, CBFS_TYPE_RAW);
+    }
+
+    #[test]
+    fn test_find_file_not_found() {
+        let rom = build_test_rom(&[("test/hello", CBFS_TYPE_RAW, b"data")]);
+        let cbfs = Cbfs::parse(&rom, ROM_BASE).unwrap();
+        assert!(cbfs.find_file("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_multiple_files() {
+        let rom = build_test_rom(&[
+            ("file/one", CBFS_TYPE_RAW, b"first"),
+            ("file/two", CBFS_TYPE_RAW, b"second"),
+        ]);
+        let cbfs = Cbfs::parse(&rom, ROM_BASE).unwrap();
+
+        let mut names = alloc::vec::Vec::new();
+        cbfs.for_each_file(|f| {
+            names.push(alloc::string::String::from(f.name));
+            true
+        });
+        assert_eq!(names, &["cbfs_master_header", "file/one", "file/two"]);
+    }
+
+    #[test]
+    fn test_bad_magic() {
+        let mut rom = vec![0u8; ROM_SIZE];
+        // Header pointer at end points to offset 0, but no valid header there
+        rom[ROM_SIZE - 4..ROM_SIZE].copy_from_slice(&ROM_BASE.to_le_bytes());
+        assert!(Cbfs::parse(&rom, ROM_BASE).is_none());
+    }
+
+    #[test]
+    fn test_struct_sizes() {
+        assert_eq!(size_of::<CbfsHeader>(), 32);
+        assert_eq!(size_of::<CbfsFileHeader>(), 24);
+        assert_eq!(CBFS_FILE_HEADER_SIZE, 24);
+    }
+}

--- a/lace-util/src/elf64.rs
+++ b/lace-util/src/elf64.rs
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+// Copyright (C) 2026, Canonical Ltd.
+// Authors: Mate Kukri <mate.kukri@canonical.com>
+
+//! Minimal ELF64 parser
+//!
+//! Parses ELF64 headers and iterates over program headers.
+
+use zerocopy::{FromBytes, Immutable, KnownLayout};
+
+const ELF_MAGIC: [u8; 4] = *b"\x7fELF";
+const ELFCLASS64: u8 = 2;
+const ELFDATA2LSB: u8 = 1;
+
+/// ELF program header type: loadable segment.
+pub const PT_LOAD: u32 = 1;
+
+#[repr(C)]
+#[derive(FromBytes, Immutable, KnownLayout)]
+struct Elf64Header {
+    e_ident: [u8; 16],
+    e_type: u16,
+    e_machine: u16,
+    e_version: u32,
+    e_entry: u64,
+    e_phoff: u64,
+    e_shoff: u64,
+    e_flags: u32,
+    e_ehsize: u16,
+    e_phentsize: u16,
+    e_phnum: u16,
+    e_shentsize: u16,
+    e_shnum: u16,
+    e_shstrndx: u16,
+}
+
+/// A parsed ELF64 program header.
+#[derive(Debug, Clone, Copy)]
+pub struct Elf64Phdr {
+    pub p_type: u32,
+    pub p_flags: u32,
+    pub p_offset: u64,
+    pub p_vaddr: u64,
+    pub p_paddr: u64,
+    pub p_filesz: u64,
+    pub p_memsz: u64,
+    pub p_align: u64,
+}
+
+#[repr(C)]
+#[derive(FromBytes, Immutable, KnownLayout)]
+struct RawElf64Phdr {
+    p_type: u32,
+    p_flags: u32,
+    p_offset: u64,
+    p_vaddr: u64,
+    p_paddr: u64,
+    p_filesz: u64,
+    p_memsz: u64,
+    p_align: u64,
+}
+
+/// A parsed ELF64 binary.
+#[derive(Debug)]
+pub struct Elf64<'a> {
+    data: &'a [u8],
+    entry: u64,
+    phoff: usize,
+    phentsize: usize,
+    phnum: usize,
+}
+
+impl<'a> Elf64<'a> {
+    /// Parse an ELF64 binary from a byte slice.
+    pub fn parse(data: &'a [u8]) -> Result<Self, &'static str> {
+        let (ehdr, _) = Elf64Header::read_from_prefix(data).map_err(|_| "ELF header too small")?;
+
+        if ehdr.e_ident[0..4] != ELF_MAGIC {
+            return Err("bad ELF magic");
+        }
+        if ehdr.e_ident[4] != ELFCLASS64 {
+            return Err("not ELF64");
+        }
+        if ehdr.e_ident[5] != ELFDATA2LSB {
+            return Err("not little-endian");
+        }
+
+        let phentsize = ehdr.e_phentsize as usize;
+        if phentsize < size_of::<RawElf64Phdr>() {
+            return Err("phentsize too small");
+        }
+
+        Ok(Self {
+            data,
+            entry: ehdr.e_entry,
+            phoff: ehdr.e_phoff as usize,
+            phentsize,
+            phnum: ehdr.e_phnum as usize,
+        })
+    }
+
+    /// Entry point address.
+    pub fn entry(&self) -> u64 {
+        self.entry
+    }
+
+    /// Iterate over program headers, calling `f` for each.
+    ///
+    /// The callback returns `true` to continue, `false` to stop.
+    pub fn for_each_phdr(&self, mut f: impl FnMut(&Elf64Phdr) -> bool) -> Result<(), &'static str> {
+        for i in 0..self.phnum {
+            let off = self.phoff + i * self.phentsize;
+            let (raw, _) =
+                RawElf64Phdr::read_from_prefix(self.data.get(off..).ok_or("phdr out of bounds")?)
+                    .map_err(|_| "phdr parse error")?;
+
+            let phdr = Elf64Phdr {
+                p_type: raw.p_type,
+                p_flags: raw.p_flags,
+                p_offset: raw.p_offset,
+                p_vaddr: raw.p_vaddr,
+                p_paddr: raw.p_paddr,
+                p_filesz: raw.p_filesz,
+                p_memsz: raw.p_memsz,
+                p_align: raw.p_align,
+            };
+
+            if !f(&phdr) {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    /// Get the file data for a program header's file portion.
+    pub fn segment_data(&self, phdr: &Elf64Phdr) -> Result<&'a [u8], &'static str> {
+        let off = phdr.p_offset as usize;
+        let len = phdr.p_filesz as usize;
+        self.data
+            .get(off..off + len)
+            .ok_or("segment data out of bounds")
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Build a minimal ELF64 binary with the given PT_LOAD segments.
+    /// Each segment is (p_vaddr, p_paddr, data).
+    fn build_elf64(entry: u64, segments: &[(u64, u64, &[u8])]) -> alloc::vec::Vec<u8> {
+        let ehdr_size = size_of::<Elf64Header>();
+        let phdr_size = size_of::<RawElf64Phdr>();
+        let phoff = ehdr_size;
+        let data_start = ehdr_size + segments.len() * phdr_size;
+
+        let mut buf = alloc::vec![0u8; data_start];
+
+        // ELF header
+        buf[0..4].copy_from_slice(b"\x7fELF");
+        buf[4] = 2; // ELFCLASS64
+        buf[5] = 1; // ELFDATA2LSB
+        buf[6] = 1; // EV_CURRENT
+        // e_type at 16
+        buf[16..18].copy_from_slice(&2u16.to_le_bytes()); // ET_EXEC
+        // e_machine at 18
+        buf[18..20].copy_from_slice(&62u16.to_le_bytes()); // EM_X86_64
+        // e_version at 20
+        buf[20..24].copy_from_slice(&1u32.to_le_bytes());
+        // e_entry at 24
+        buf[24..32].copy_from_slice(&entry.to_le_bytes());
+        // e_phoff at 32
+        buf[32..40].copy_from_slice(&(phoff as u64).to_le_bytes());
+        // e_ehsize at 52
+        buf[52..54].copy_from_slice(&(ehdr_size as u16).to_le_bytes());
+        // e_phentsize at 54
+        buf[54..56].copy_from_slice(&(phdr_size as u16).to_le_bytes());
+        // e_phnum at 56
+        buf[56..58].copy_from_slice(&(segments.len() as u16).to_le_bytes());
+
+        // Program headers and data
+        for (i, &(vaddr, paddr, data)) in segments.iter().enumerate() {
+            let file_offset = buf.len();
+            buf.extend_from_slice(data);
+
+            let phdr_off = phoff + i * phdr_size;
+            // p_type = PT_LOAD (1)
+            buf[phdr_off..phdr_off + 4].copy_from_slice(&1u32.to_le_bytes());
+            // p_offset
+            buf[phdr_off + 8..phdr_off + 16].copy_from_slice(&(file_offset as u64).to_le_bytes());
+            // p_vaddr
+            buf[phdr_off + 16..phdr_off + 24].copy_from_slice(&vaddr.to_le_bytes());
+            // p_paddr
+            buf[phdr_off + 24..phdr_off + 32].copy_from_slice(&paddr.to_le_bytes());
+            // p_filesz
+            buf[phdr_off + 32..phdr_off + 40].copy_from_slice(&(data.len() as u64).to_le_bytes());
+            // p_memsz (same as filesz for simplicity)
+            buf[phdr_off + 40..phdr_off + 48].copy_from_slice(&(data.len() as u64).to_le_bytes());
+        }
+
+        buf
+    }
+
+    #[test]
+    fn test_parse_valid_elf() {
+        let elf_data = build_elf64(0x100000, &[(0x100000, 0x100000, b"hello")]);
+        let elf = Elf64::parse(&elf_data).unwrap();
+        assert_eq!(elf.entry(), 0x100000);
+    }
+
+    #[test]
+    fn test_bad_magic() {
+        let mut data = build_elf64(0, &[]);
+        data[0] = 0; // corrupt magic
+        assert!(Elf64::parse(&data).is_err());
+    }
+
+    #[test]
+    fn test_not_elf64() {
+        let mut data = build_elf64(0, &[]);
+        data[4] = 1; // ELFCLASS32
+        assert_eq!(Elf64::parse(&data).unwrap_err(), "not ELF64");
+    }
+
+    #[test]
+    fn test_not_little_endian() {
+        let mut data = build_elf64(0, &[]);
+        data[5] = 2; // ELFDATA2MSB
+        assert_eq!(Elf64::parse(&data).unwrap_err(), "not little-endian");
+    }
+
+    #[test]
+    fn test_program_headers() {
+        let seg1 = b"segment one data";
+        let seg2 = b"two";
+        let elf_data = build_elf64(
+            0x200000,
+            &[(0x100000, 0x100000, seg1), (0x200000, 0x200000, seg2)],
+        );
+        let elf = Elf64::parse(&elf_data).unwrap();
+
+        let mut phdrs = alloc::vec::Vec::new();
+        elf.for_each_phdr(|phdr| {
+            phdrs.push(*phdr);
+            true
+        })
+        .unwrap();
+
+        assert_eq!(phdrs.len(), 2);
+        assert_eq!(phdrs[0].p_type, PT_LOAD);
+        assert_eq!(phdrs[0].p_vaddr, 0x100000);
+        assert_eq!(phdrs[0].p_filesz, seg1.len() as u64);
+        assert_eq!(phdrs[1].p_vaddr, 0x200000);
+
+        // Check segment data
+        let data = elf.segment_data(&phdrs[0]).unwrap();
+        assert_eq!(data, seg1);
+    }
+
+    #[test]
+    fn test_too_small() {
+        assert!(Elf64::parse(&[0; 10]).is_err());
+    }
+}

--- a/lace-util/src/lib.rs
+++ b/lace-util/src/lib.rs
@@ -13,6 +13,7 @@ pub mod chid;
 pub mod chid_mapping;
 pub mod chid_matcher;
 pub mod edid;
+pub mod elf64;
 #[cfg(feature = "grub")]
 pub mod grub;
 pub mod peimage;

--- a/lace-util/src/lib.rs
+++ b/lace-util/src/lib.rs
@@ -8,6 +8,7 @@ extern crate alloc;
 
 pub mod acpi;
 pub mod bls;
+pub mod cbfs;
 pub mod chid;
 pub mod chid_mapping;
 pub mod chid_matcher;

--- a/lace-util/src/lib.rs
+++ b/lace-util/src/lib.rs
@@ -6,6 +6,7 @@
 
 extern crate alloc;
 
+pub mod acpi;
 pub mod bls;
 pub mod chid;
 pub mod chid_mapping;

--- a/tools/flashedit/Cargo.toml
+++ b/tools/flashedit/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "flashedit"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+clap.workspace = true
+lace-util = { path = "../../lace-util", default-features = false }
+zerocopy = { workspace = true, features = ["derive"] }

--- a/tools/flashedit/src/main.rs
+++ b/tools/flashedit/src/main.rs
@@ -1,0 +1,360 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+// Copyright (C) 2026, Canonical Ltd.
+// Authors: Mate Kukri <mate.kukri@canonical.com>
+
+//! flashedit: Build and manipulate CBFS flash images
+
+use clap::{Parser, Subcommand};
+use lace_util::cbfs::*;
+use std::fs;
+use std::path::PathBuf;
+use zerocopy::byteorder::U32;
+use zerocopy::{FromBytes, IntoBytes};
+
+/// Write a CBFS file header + name at `entry_start` in `rom`, with the
+/// header's `offset` field set to `data_offset` (distance from header
+/// start to the file's data).
+fn write_file_header(
+    rom: &mut [u8],
+    entry_start: usize,
+    name: &str,
+    type_: u32,
+    data_len: usize,
+    data_offset: usize,
+) {
+    let hdr = CbfsFileHeader {
+        magic: CBFS_FILE_MAGIC,
+        len: U32::new(data_len as u32),
+        type_: U32::new(type_),
+        attributes_offset: U32::new(0),
+        offset: U32::new(data_offset as u32),
+    };
+    rom[entry_start..entry_start + CBFS_FILE_HEADER_SIZE].copy_from_slice(hdr.as_bytes());
+    let name_start = entry_start + CBFS_FILE_HEADER_SIZE;
+    rom[name_start..name_start + name.len()].copy_from_slice(name.as_bytes());
+    rom[name_start + name.len()] = 0;
+}
+
+/// Place a file at a given data-content offset within `rom`, following
+/// cbfstool's `cbfs_add_entry_at` in `coreboot/util/cbfstool/cbfs_image.c`.
+///
+/// The file header goes at `content_offset - header_size`, aligned
+/// down to `CBFS_ALIGNMENT`. Any gap between `cursor` and the header
+/// start is filled with a `CBFS_TYPE_NULL` entry. Returns the cursor
+/// just past the newly placed entry.
+fn add_entry_at(
+    rom: &mut [u8],
+    cursor: usize,
+    content_offset: usize,
+    name: &str,
+    type_: u32,
+    data: &[u8],
+) -> usize {
+    let header_size = cbfs_file_header_total_size(name);
+    assert!(
+        content_offset >= cursor + header_size,
+        "no room for '{}' header at content offset {:#x}",
+        name,
+        content_offset
+    );
+    assert!(
+        content_offset + data.len() <= rom.len(),
+        "'{}' data ({} bytes) overflows ROM at content offset {:#x}",
+        name,
+        data.len(),
+        content_offset
+    );
+    // Align the header start down so every CBFS entry starts on a
+    // `CBFS_ALIGNMENT` boundary; the gap between the aligned start and
+    // the data is absorbed by the header's `offset` field.
+    let entry_start = (content_offset - header_size) & !(CBFS_ALIGNMENT - 1);
+    let data_offset = content_offset - entry_start;
+
+    // Fill the gap from the previous cursor to this entry with a null
+    // entry (or leave 0xFF if smaller than the minimum entry header).
+    let gap = entry_start - cursor;
+    let null_hdr = cbfs_file_header_total_size("");
+    if gap >= null_hdr {
+        write_file_header(rom, cursor, "", CBFS_TYPE_NULL, gap - null_hdr, null_hdr);
+    }
+
+    // Write the file header + name + data.
+    write_file_header(rom, entry_start, name, type_, data.len(), data_offset);
+    rom[content_offset..content_offset + data.len()].copy_from_slice(data);
+
+    cbfs_align_up(entry_start + data_offset + data.len())
+}
+
+#[derive(Parser)]
+#[command(name = "flashedit", about = "Build and manipulate CBFS flash images")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Create a new CBFS flash image
+    Create {
+        /// Output file path
+        #[arg(short, long)]
+        output: PathBuf,
+        /// ROM size in bytes (e.g. 65536 for 64KB, or use suffixes like 64K, 1M)
+        #[arg(short, long, value_parser = parse_size)]
+        size: usize,
+        /// Bootblock flat binary file
+        #[arg(short, long)]
+        bootblock: PathBuf,
+        /// Files to add: name=path pairs (e.g. firmware=firmware.elf)
+        #[arg(short, long = "file", value_parser = parse_file_arg)]
+        files: Vec<(String, PathBuf)>,
+    },
+    /// List files in a CBFS image
+    List {
+        /// Input CBFS image file
+        #[arg(short, long)]
+        input: PathBuf,
+    },
+}
+
+fn parse_size(s: &str) -> Result<usize, String> {
+    let s = s.trim();
+    if let Some(prefix) = s.strip_suffix('K') {
+        prefix
+            .trim()
+            .parse::<usize>()
+            .map(|n| n * 1024)
+            .map_err(|e| e.to_string())
+    } else if let Some(prefix) = s.strip_suffix('M') {
+        prefix
+            .trim()
+            .parse::<usize>()
+            .map(|n| n * 1024 * 1024)
+            .map_err(|e| e.to_string())
+    } else {
+        s.parse::<usize>().map_err(|e| e.to_string())
+    }
+}
+
+fn parse_file_arg(s: &str) -> Result<(String, PathBuf), String> {
+    let (name, path) = s.split_once('=').ok_or("expected name=path")?;
+    Ok((name.to_string(), PathBuf::from(path)))
+}
+
+fn cmd_create(output: PathBuf, size: usize, bootblock: PathBuf, files: Vec<(String, PathBuf)>) {
+    // ROM size is stored in u32 fields of the CBFS header and used to
+    // compute `0x1_0000_0000 - size` as a 32-bit base; reject anything
+    // outside the supported range up front.
+    if size == 0 || size > u32::MAX as usize {
+        panic!("ROM size ({}) must be in (0, 2^32]", size);
+    }
+
+    let bb_data = fs::read(&bootblock)
+        .unwrap_or_else(|e| panic!("Failed to read bootblock {:?}: {}", bootblock, e));
+
+    if bb_data.len() > size {
+        panic!(
+            "Bootblock ({} bytes) exceeds ROM size ({} bytes)",
+            bb_data.len(),
+            size
+        );
+    }
+
+    // Last 4 bytes of ROM store the CBFS master-header pointer and
+    // overlap the bootblock's reset-vector padding region, so the
+    // bootblock must cover them.
+    if bb_data.len() < 4 {
+        panic!(
+            "Bootblock ({} bytes) is too short to host the CBFS header pointer",
+            bb_data.len()
+        );
+    }
+
+    // Start with empty ROM (0xFF)
+    let mut rom = vec![0xFFu8; size];
+
+    // Master header lives in its own CBFS file at the start of the ROM.
+    let master_header = CbfsHeader {
+        magic: U32::new(CBFS_HEADER_MAGIC),
+        version: U32::new(CBFS_HEADER_VERSION2),
+        romsize: U32::new(size as u32),
+        bootblocksize: U32::new(bb_data.len() as u32),
+        align: U32::new(CBFS_ALIGNMENT as u32),
+        offset: U32::new(0),
+        architecture: U32::new(CBFS_ARCHITECTURE_X86),
+        _pad: U32::new(0),
+    };
+    let master_header_bytes = master_header.as_bytes();
+    let mh_name = "cbfs_master_header";
+    let mh_content_offset = cbfs_file_header_total_size(mh_name);
+    let mut cursor = add_entry_at(
+        &mut rom,
+        0,
+        mh_content_offset,
+        mh_name,
+        CBFS_TYPE_RAW,
+        master_header_bytes,
+    );
+    eprintln!(
+        "  {:40} offset={:#010x} size={}",
+        mh_name,
+        mh_content_offset,
+        master_header_bytes.len()
+    );
+
+    // User files, packed after the master header.
+    for (name, path) in &files {
+        let data = fs::read(path).unwrap_or_else(|e| panic!("Failed to read {:?}: {}", path, e));
+        let header_size = cbfs_file_header_total_size(name);
+        let content_offset = cbfs_align_up(cursor + header_size);
+        eprintln!(
+            "  {:40} offset={:#010x} size={}",
+            name,
+            content_offset,
+            data.len()
+        );
+        cursor = add_entry_at(&mut rom, cursor, content_offset, name, CBFS_TYPE_RAW, &data);
+    }
+
+    // Bootblock sits at the top of ROM so the x86 reset vector lands
+    // at 0xFFFFFFF0. It's tracked as a CBFS entry so cbfstool and
+    // other consumers see it; the gap between `cursor` and the
+    // bootblock header becomes the trailing null entry.
+    let bb_content_offset = size - bb_data.len();
+    eprintln!(
+        "  {:40} offset={:#010x} size={}",
+        "bootblock",
+        bb_content_offset,
+        bb_data.len()
+    );
+    add_entry_at(
+        &mut rom,
+        cursor,
+        bb_content_offset,
+        "bootblock",
+        CBFS_TYPE_BOOTBLOCK,
+        &bb_data,
+    );
+
+    // Write header pointer at the last 4 bytes of ROM. This overlaps
+    // the bootblock's reset-vector padding; the reset vector sits at
+    // 0xFFFFFFF0 (last 16 bytes) and only the first 12 bytes carry
+    // actual code, so the final 4 bytes belong to this pointer.
+    let rom_base: u64 = 0x1_0000_0000u64 - size as u64;
+    let header_addr = (rom_base + mh_content_offset as u64) as u32;
+    rom[size - 4..size].copy_from_slice(&header_addr.to_le_bytes());
+
+    fs::write(&output, &rom).unwrap_or_else(|e| panic!("Failed to write {:?}: {}", output, e));
+    eprintln!("Created CBFS image {:?} ({} bytes)", output, size);
+}
+
+fn cmd_list(input: PathBuf) {
+    let rom = fs::read(&input).unwrap_or_else(|e| panic!("Failed to read {:?}: {}", input, e));
+
+    let size = rom.len();
+
+    if size < 4 || size > u32::MAX as usize {
+        panic!("ROM size ({}) is not a valid CBFS image size", size);
+    }
+
+    // Read header pointer from last 4 bytes
+    let ptr_bytes: [u8; 4] = rom[size - 4..size].try_into().unwrap();
+    let header_addr = u32::from_le_bytes(ptr_bytes);
+    let rom_base = 0x1_0000_0000u64 - size as u64;
+    let header_offset = (header_addr as u64)
+        .checked_sub(rom_base)
+        .and_then(|o| usize::try_from(o).ok())
+        .unwrap_or_else(|| panic!("Header pointer {:#010x} out of range", header_addr));
+
+    if header_offset + size_of::<CbfsHeader>() > size {
+        panic!("Header pointer out of range");
+    }
+
+    let (header, _) =
+        CbfsHeader::read_from_prefix(&rom[header_offset..]).expect("Failed to parse CBFS header");
+
+    if header.magic.get() != CBFS_HEADER_MAGIC {
+        panic!("Invalid CBFS header magic: {:#010x}", header.magic.get());
+    }
+
+    println!(
+        "CBFS image: {} bytes, bootblock {} bytes, alignment {}",
+        header.romsize.get(),
+        header.bootblocksize.get(),
+        header.align.get()
+    );
+    println!();
+
+    // Walk file entries all the way to the end of the ROM; the
+    // bootblock is the last CBFS entry.
+    let entries_start = header.offset.get() as usize;
+    let mut cursor = entries_start;
+
+    println!(
+        "{:40} {:>10} {:>10} {:>10}",
+        "Name", "Offset", "Size", "Type"
+    );
+    println!("{}", "-".repeat(74));
+
+    while cursor + CBFS_FILE_HEADER_SIZE <= size {
+        let (file_hdr, _) = match CbfsFileHeader::read_from_prefix(&rom[cursor..]) {
+            Ok(h) => h,
+            Err(_) => break,
+        };
+
+        if file_hdr.magic != CBFS_FILE_MAGIC {
+            break;
+        }
+
+        let type_ = file_hdr.type_.get();
+        if type_ == CBFS_TYPE_DELETED {
+            break;
+        }
+
+        let data_offset = file_hdr.offset.get() as usize;
+        let data_len = file_hdr.len.get() as usize;
+
+        // Extract filename
+        let name_start = cursor + CBFS_FILE_HEADER_SIZE;
+        let name_end = cursor + data_offset;
+        let name_bytes = &rom[name_start..name_end];
+        let name_len = name_bytes
+            .iter()
+            .position(|&b| b == 0)
+            .unwrap_or(name_bytes.len());
+        let name = std::str::from_utf8(&name_bytes[..name_len]).unwrap_or("???");
+
+        let type_str = match type_ {
+            CBFS_TYPE_NULL => "(empty)",
+            CBFS_TYPE_BOOTBLOCK => "bootblock",
+            CBFS_TYPE_RAW => "raw",
+            _ => "unknown",
+        };
+
+        println!(
+            "{:40} {:#010x} {:>10} {:>10}",
+            name, cursor, data_len, type_str
+        );
+
+        // Advance to next entry (aligned)
+        let entry_size = cbfs_align_up(data_offset + data_len);
+        cursor += entry_size;
+    }
+}
+
+fn main() {
+    let cli = Cli::parse();
+    match cli.command {
+        Command::Create {
+            output,
+            size,
+            bootblock,
+            files,
+        } => {
+            cmd_create(output, size, bootblock, files);
+        }
+        Command::List { input } => {
+            cmd_list(input);
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds a new crate lace-drivers with low-level hardware access helpers and drivers that will be used in lace firmware. In no particular order:

1. Add low-level x86 primitives for Port based I/O, PCI configuration access using port based I/O, and an 8250 UART driver using port based I/O.
2. A generic PCI driver for MMIO configuration access (ECAM) and BAR (base address register) allocation.
3. A qemu fw_cfg driver for reading memory map, ACPI tables, and various configuration from the hypervisor. This also supports DMA for fast read of large files.
4. A generic virtio virt queue driver, and a virtio-blk block device driver on top of it.