### PR TITLE
ci: Note Rust 2024 prelude in Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,6 +16,13 @@ They use the following library crates:
 * `lace-util` - Platform-independent utilities
 * `lace-util-derive` - Platform-independent macros
 
+### Rust Edition
+
+The workspace uses **Rust edition 2024**. Notably, `size_of`,
+`size_of_val`, `align_of`, and `align_of_val` are in the prelude and
+do **not** need to be imported from `core::mem` / `std::mem`. Do not
+flag unqualified uses of these as missing imports.
+
 ### Build System
 
 The project uses a **Cargo workspace**.


### PR DESCRIPTION
Copilot reviewers have been flagging unqualified `size_of` calls across the new lace-util parsers as missing imports. They are not missing: `size_of`, `size_of_val`, `align_of`, and `align_of_val` are in the Rust 2024 prelude, and this workspace is edition 2024. Document that in the Copilot instructions so the noise goes away on future PRs.