### PR TITLE
Add CBFS implementation and flashedit tool for creating CBFS images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784a4df722dc6267a04af36895398f59d21d07dce47232adf31ec0ff2fa45e67"
 
 [[package]]
+name = "flashedit"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "lace-util",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "lace-util-derive-impl",
     "tools/collect-hwids",
     "tools/fakeedid",
+    "tools/flashedit",
     "tools/pewrap",
     "tools/xtask",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -115,6 +115,7 @@ exceptions = [
     { allow = ["GPL-2.0-only"], crate = "lace-util" },
     { allow = ["GPL-2.0-only"], crate = "lace-util-derive" },
     { allow = ["GPL-2.0-only"], crate = "lace-util-derive-impl" },
+    { allow = ["GPL-2.0-only"], crate = "flashedit" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,

--- a/lace-util/src/cbfs/mod.rs
+++ b/lace-util/src/cbfs/mod.rs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+// Copyright (C) 2026, Canonical Ltd.
+// Authors: Mate Kukri <mate.kukri@canonical.com>
+
+//! CBFS (coreboot filesystem) structures, reader, and writer
+//!
+//! Provides the on-flash data structures, a reader for memory-mapped
+//! flash images, and a writer for constructing or updating CBFS images.
+
+mod r#priv;
+mod reader;
+mod writer;
+
+pub use reader::{CbfsFile, CbfsFiles, CbfsReader};
+pub use writer::CbfsWriter;
+
+use lace_util_derive::Display;
+use zerocopy::byteorder::{BE, U32};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+
+// Public constants for CBFS format
+
+/// CBFS header magic: 'ORBC' in big-endian.
+pub const CBFS_HEADER_MAGIC: u32 = 0x4F524243;
+/// CBFS header version 2: '1112' in big-endian.
+pub const CBFS_HEADER_VERSION2: u32 = 0x31313132;
+/// CBFS file magic: "LARCHIVE".
+pub const CBFS_FILE_MAGIC: [u8; 8] = *b"LARCHIVE";
+/// CBFS default alignment.
+pub const CBFS_DEFAULT_ALIGNMENT: u32 = 64;
+/// CBFS architecture: x86.
+pub const CBFS_ARCHITECTURE_X86: u32 = 0x00000001;
+
+// File types
+pub const CBFS_TYPE_DELETED: u32 = 0x00000000;
+pub const CBFS_TYPE_NULL: u32 = 0xFFFFFFFF;
+pub const CBFS_TYPE_BOOTBLOCK: u32 = 0x01;
+pub const CBFS_TYPE_RAW: u32 = 0x50;
+
+/// Errors returned by CBFS operations.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Display)]
+pub enum CbfsError {
+    /// ROM size must be a power of two between 4 and 2 GiB.
+    #[display("ROM size must be a power of two between 4 and 2 GiB")]
+    InvalidRomSize,
+    /// ROM base address must be a multiple of ROM size.
+    #[display("ROM base address must be a multiple of ROM size")]
+    InvalidRomBase,
+    /// Header pointer at end of ROM does not resolve to a valid offset.
+    #[display("header pointer at end of ROM does not resolve to a valid offset")]
+    InvalidHeaderPointer,
+    /// Master header has invalid magic, version, size, alignment, or offset.
+    #[display("master header has invalid magic, version, size, alignment, or offset")]
+    InvalidHeader,
+    /// Alignment must be a power of two.
+    #[display("alignment must be a power of two")]
+    InvalidAlignment,
+    /// Entry has valid magic but invalid offset, length, or name.
+    ///
+    /// When returned by the walker, iteration is terminated: subsequent
+    /// calls will return `None`.
+    #[display("entry has valid magic but invalid offset, length, or name")]
+    CorruptEntry,
+    /// File name contains a NUL byte.
+    #[display("file name contains a NUL byte")]
+    NulInName,
+    /// Data or name length exceeds `u32::MAX`.
+    #[display("data or name length exceeds u32::MAX")]
+    TooLarge,
+    /// No NULL entry large enough for the requested file.
+    #[display("no NULL entry large enough for the requested file")]
+    NoSpace,
+}
+
+/// CBFS master header (on-flash format, all big-endian).
+#[repr(C)]
+#[derive(Clone, FromBytes, IntoBytes, Immutable, KnownLayout)]
+pub struct CbfsHeader {
+    pub magic: U32<BE>,
+    pub version: U32<BE>,
+    pub romsize: U32<BE>,
+    pub bootblocksize: U32<BE>,
+    pub align: U32<BE>,
+    pub offset: U32<BE>,
+    pub architecture: U32<BE>,
+    pub _pad: U32<BE>,
+}
+
+/// CBFS file entry header (on-flash format, all big-endian).
+#[repr(C)]
+#[derive(Clone, FromBytes, IntoBytes, Immutable, KnownLayout)]
+pub struct CbfsFileHeader {
+    pub magic: [u8; 8],
+    pub len: U32<BE>,
+    pub r#type: U32<BE>,
+    pub attributes_offset: U32<BE>,
+    pub offset: U32<BE>,
+}

--- a/lace-util/src/cbfs/priv.rs
+++ b/lace-util/src/cbfs/priv.rs
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+// Copyright (C) 2026, Canonical Ltd.
+// Authors: Mate Kukri <mate.kukri@canonical.com>
+
+//! Internal CBFS helpers shared between reader and writer.
+
+use zerocopy::FromBytes;
+use zerocopy::byteorder::{LE, U32};
+
+use super::*;
+use crate::{UsizeIsAtLeastU32, align_up_checked};
+
+/// Parse a CBFS master header from a ROM image.
+///
+/// `rom_base` is the absolute address where the ROM is mapped (e.g.
+/// `0xFFC00000` for a 4MB ROM). This is needed to resolve the header
+/// pointer at the last 4 bytes of the ROM, which stores an absolute address.
+///
+/// Returns the parsed header and the entries alignment/offset on success.
+pub(crate) fn parse_header(rom: &[u8], rom_base: u32) -> Result<(CbfsHeader, u32, u32), CbfsError> {
+    // Verify ROM size and ROM base address
+    let rom_size: u32 = rom
+        .len()
+        .try_into()
+        .ok()
+        .filter(|s: &u32| s.is_power_of_two())
+        .ok_or(CbfsError::InvalidRomSize)?;
+
+    if !rom_base.is_multiple_of(rom_size) {
+        return Err(CbfsError::InvalidRomBase);
+    }
+
+    // Read header pointer from last 4 bytes of ROM (little-endian absolute address)
+    let (_, ptr) = U32::<LE>::read_from_suffix(rom).map_err(|_| CbfsError::InvalidRomSize)?;
+
+    // Then subtract the ROM base address to get the header offset and read the header
+    let header_off = ptr
+        .get()
+        .checked_sub(rom_base)
+        .ok_or(CbfsError::InvalidHeaderPointer)?;
+    let (header, _) = rom
+        .get(header_off.as_usize()..)
+        .and_then(|s| CbfsHeader::read_from_prefix(s).ok())
+        .ok_or(CbfsError::InvalidHeaderPointer)?;
+
+    // Verify header fields
+    if header.magic.get() != CBFS_HEADER_MAGIC
+        || header.version.get() != CBFS_HEADER_VERSION2
+        || header.romsize.get() != rom_size
+        || !header.align.get().is_power_of_two()
+        || header.align > rom_size
+        || header.offset > rom_size
+    {
+        return Err(CbfsError::InvalidHeader);
+    }
+
+    let align = header.align.get();
+    let offset = header.offset.get();
+
+    Ok((header, align, offset))
+}
+
+/// Positional information about a parsed CBFS entry.
+///
+/// All positions are absolute ROM offsets stored as `u32`, matching the
+/// on-flash format. Use [`.as_usize()`](crate::UsizeIsAtLeastU32) when
+/// indexing into a ROM buffer. Contains only scalars (no references
+/// into the ROM), so the borrow used to produce this value is released
+/// immediately and callers can mutate the ROM between calls to
+/// [`CbfsEntryWalker::next`].
+pub(crate) struct CbfsEntryInfo {
+    /// Start of this entry's header in the ROM.
+    pub entry_start: u32,
+    /// End of this entry's data region in the ROM.
+    pub entry_end: u32,
+    /// Entry type field.
+    pub entry_type: u32,
+    /// Start of the file data in the ROM.
+    pub data_start: u32,
+    /// Length of data.
+    pub data_len: u32,
+    /// Start of the NUL-terminated name in the ROM.
+    pub name_start: u32,
+    /// Length of the name (excluding NUL).
+    pub name_len: u32,
+}
+
+/// Iterator-like walker over CBFS entries.
+///
+/// Borrows the ROM only during each [`next`](Self::next) call, allowing the
+/// caller to mutate the ROM between iterations.
+pub(crate) struct CbfsEntryWalker {
+    align: u32,
+    cursor: Option<u32>,
+}
+
+impl CbfsEntryWalker {
+    pub fn new(align: u32, offset: u32) -> Self {
+        Self {
+            align,
+            cursor: Some(offset),
+        }
+    }
+
+    /// Parse the entry at the current cursor and advance.
+    ///
+    /// Returns `None` when there are no more entries (end of ROM or no
+    /// valid magic). Returns `Some(Err(CbfsError::CorruptEntry))` when
+    /// the entry has valid magic but invalid metadata; iteration is
+    /// terminated in that case.
+    pub fn next(&mut self, rom: &[u8]) -> Option<Result<CbfsEntryInfo, CbfsError>> {
+        let cursor = self.cursor?;
+        let rom_len: u32 = rom.len().try_into().ok()?;
+
+        let hdr_size = crate::const_u32(size_of::<CbfsFileHeader>());
+
+        // No magic match → end of iteration (None), not an error.
+        let (hdr, _) = rom
+            .get(cursor.as_usize()..)
+            .and_then(|s| CbfsFileHeader::read_from_prefix(s).ok())
+            .filter(|(hdr, _)| hdr.magic == CBFS_FILE_MAGIC)?;
+
+        // Magic matched — from here on, failures are corruption.
+        let result = (|| {
+            let data_offset = hdr.offset.get();
+            if data_offset < hdr_size
+                || data_offset > rom_len.checked_sub(cursor).ok_or(CbfsError::CorruptEntry)?
+            {
+                return Err(CbfsError::CorruptEntry);
+            }
+
+            let data_len = hdr.len.get();
+            if data_len > rom_len - cursor - data_offset {
+                return Err(CbfsError::CorruptEntry);
+            }
+
+            let name_start = cursor + hdr_size;
+            let name_end = cursor + data_offset;
+            let name_len: u32 = rom[name_start.as_usize()..name_end.as_usize()]
+                .iter()
+                .position(|&b| b == 0)
+                .ok_or(CbfsError::CorruptEntry)?
+                .try_into()
+                .map_err(|_| CbfsError::CorruptEntry)?;
+
+            let data_start = cursor + data_offset;
+            let entry_end = data_start + data_len;
+
+            Ok(CbfsEntryInfo {
+                entry_start: cursor,
+                entry_end,
+                entry_type: hdr.r#type.get(),
+                data_start,
+                data_len,
+                name_start,
+                name_len,
+            })
+        })();
+
+        match &result {
+            Ok(info) => self.cursor = align_up_checked!(info.entry_end, self.align),
+            Err(_) => self.cursor = None,
+        }
+
+        Some(result)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::cbfs::writer::CbfsWriter;
+    use crate::const_u32;
+    use zerocopy::IntoBytes;
+
+    const ROM_SIZE: u32 = 4096;
+    const ROM_BASE: u32 = 0xFFFF_F000;
+
+    fn valid_rom() -> Vec<u8> {
+        let mut rom = vec![0xFFu8; ROM_SIZE.as_usize()];
+        CbfsWriter::create(&mut rom, ROM_BASE, CBFS_DEFAULT_ALIGNMENT).unwrap();
+        rom
+    }
+
+    /// Position of the first entry after the master header.
+    fn second_entry_pos() -> usize {
+        let mh_total = size_of::<CbfsFileHeader>() + b"cbfs_master_header\0".len();
+        crate::align_up!(
+            mh_total + size_of::<CbfsHeader>(),
+            CBFS_DEFAULT_ALIGNMENT.as_usize()
+        )
+    }
+
+    fn rom_with_header_field(mutate: impl FnOnce(&mut CbfsHeader)) -> Vec<u8> {
+        let mut hdr = CbfsHeader {
+            magic: CBFS_HEADER_MAGIC.into(),
+            version: CBFS_HEADER_VERSION2.into(),
+            romsize: ROM_SIZE.into(),
+            bootblocksize: 4.into(),
+            align: CBFS_DEFAULT_ALIGNMENT.into(),
+            offset: 0.into(),
+            architecture: CBFS_ARCHITECTURE_X86.into(),
+            _pad: 0.into(),
+        };
+        mutate(&mut hdr);
+        let mut rom = vec![0u8; ROM_SIZE.as_usize()];
+        rom[..size_of::<CbfsHeader>()].copy_from_slice(hdr.as_bytes());
+        rom[ROM_SIZE.as_usize() - 4..].copy_from_slice(&ROM_BASE.to_le_bytes());
+        rom
+    }
+
+    fn corrupt_entry(offset_val: u32, len_val: u32) -> CbfsFileHeader {
+        CbfsFileHeader {
+            magic: CBFS_FILE_MAGIC,
+            len: len_val.into(),
+            r#type: CBFS_TYPE_RAW.into(),
+            attributes_offset: 0.into(),
+            offset: offset_val.into(),
+        }
+    }
+
+    // --- parse_header ---
+
+    #[test]
+    fn test_parse_header_valid() {
+        let rom = valid_rom();
+        let (hdr, align, offset) = parse_header(&rom, ROM_BASE).unwrap();
+        assert_eq!(hdr.magic.get(), CBFS_HEADER_MAGIC);
+        assert_eq!(align, CBFS_DEFAULT_ALIGNMENT);
+        assert_eq!(offset, 0);
+    }
+
+    #[test]
+    fn test_parse_header_rejects_invalid() {
+        // Empty ROM
+        assert!(parse_header(&[], 0).is_err());
+        // Pointer below ROM base
+        let mut rom = vec![0u8; ROM_SIZE.as_usize()];
+        rom[ROM_SIZE.as_usize() - 4..].copy_from_slice(&(ROM_BASE - 1).to_le_bytes());
+        assert!(parse_header(&rom, ROM_BASE).is_err());
+        // Bad magic (zeros at header offset)
+        let rom = rom_with_header_field(|h| h.magic = 0.into());
+        assert!(parse_header(&rom, ROM_BASE).is_err());
+        // Bad version
+        let rom = rom_with_header_field(|h| h.version = 0xDEAD.into());
+        assert!(parse_header(&rom, ROM_BASE).is_err());
+        // Mismatched romsize
+        let rom = rom_with_header_field(|h| h.romsize = (ROM_SIZE + 1).into());
+        assert!(parse_header(&rom, ROM_BASE).is_err());
+        // Non-power-of-two alignment
+        let rom = rom_with_header_field(|h| h.align = 3.into());
+        assert!(parse_header(&rom, ROM_BASE).is_err());
+        // Offset past ROM
+        let rom = rom_with_header_field(|h| h.offset = (ROM_SIZE + 1).into());
+        assert!(parse_header(&rom, ROM_BASE).is_err());
+    }
+
+    // --- CbfsEntryWalker ---
+
+    #[test]
+    fn test_walker_valid_image() {
+        let rom = valid_rom();
+        let (_, align, offset) = parse_header(&rom, ROM_BASE).unwrap();
+        let mut w = CbfsEntryWalker::new(align, offset);
+
+        let e = w.next(&rom).unwrap().unwrap();
+        assert_eq!(e.entry_type, CBFS_TYPE_RAW);
+        assert_eq!(
+            &rom[e.name_start.as_usize()..(e.name_start + e.name_len).as_usize()],
+            b"cbfs_master_header"
+        );
+
+        let e = w.next(&rom).unwrap().unwrap();
+        assert_eq!(e.entry_type, CBFS_TYPE_NULL);
+
+        assert!(w.next(&rom).is_none());
+    }
+
+    #[test]
+    fn test_walker_stops_on_corrupt_entry() {
+        let cases: &[(u32, u32)] = &[
+            (0, 0),                                                 // offset = 0
+            (8, 0),                                                 // offset < header size
+            (ROM_SIZE, 0),                                          // offset past ROM
+            (const_u32(size_of::<CbfsFileHeader>()) + 1, ROM_SIZE), // len past ROM
+        ];
+        let pos = second_entry_pos();
+
+        for &(off, len) in cases {
+            let mut rom = valid_rom();
+            let entry = corrupt_entry(off, len);
+            rom[pos..pos + size_of::<CbfsFileHeader>()].copy_from_slice(entry.as_bytes());
+
+            let (_, align, offset) = parse_header(&rom, ROM_BASE).unwrap();
+            let mut w = CbfsEntryWalker::new(align, offset);
+            w.next(&rom); // master header
+            assert!(
+                matches!(w.next(&rom), Some(Err(CbfsError::CorruptEntry))),
+                "expected CorruptEntry for offset={off}, len={len}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_walker_stops_on_missing_nul() {
+        let mut rom = valid_rom();
+        let pos = second_entry_pos();
+        let data_offset = size_of::<CbfsFileHeader>() + 4;
+        let entry = corrupt_entry(const_u32(data_offset), 0);
+        rom[pos..pos + size_of::<CbfsFileHeader>()].copy_from_slice(entry.as_bytes());
+        rom[pos + size_of::<CbfsFileHeader>()..pos + data_offset].fill(b'A');
+
+        let (_, align, offset) = parse_header(&rom, ROM_BASE).unwrap();
+        let mut w = CbfsEntryWalker::new(align, offset);
+        w.next(&rom);
+        assert!(matches!(w.next(&rom), Some(Err(CbfsError::CorruptEntry))));
+    }
+}

--- a/lace-util/src/cbfs/reader.rs
+++ b/lace-util/src/cbfs/reader.rs
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+// Copyright (C) 2026, Canonical Ltd.
+// Authors: Mate Kukri <mate.kukri@canonical.com>
+
+//! CBFS image reader.
+
+use super::r#priv::{CbfsEntryWalker, parse_header};
+use super::*;
+use crate::UsizeIsAtLeastU32;
+
+/// A parsed CBFS image backed by a memory-mapped ROM region.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct CbfsReader<'a> {
+    rom: &'a [u8],
+    align: u32,
+    offset: u32,
+}
+
+/// A file found in a CBFS image.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct CbfsFile<'a> {
+    pub name: &'a [u8],
+    pub data: &'a [u8],
+    pub r#type: u32,
+    /// Absolute offset of the file data within the ROM.
+    pub offset: u32,
+}
+
+/// Iterator over CBFS file entries.
+pub struct CbfsFiles<'a> {
+    rom: &'a [u8],
+    walker: CbfsEntryWalker,
+}
+
+impl<'a> Iterator for CbfsFiles<'a> {
+    type Item = Result<CbfsFile<'a>, CbfsError>;
+
+    fn next(&mut self) -> Option<Result<CbfsFile<'a>, CbfsError>> {
+        let entry = match self.walker.next(self.rom)? {
+            Ok(e) => e,
+            Err(e) => return Some(Err(e)),
+        };
+        Some(Ok(CbfsFile {
+            name: &self.rom
+                [entry.name_start.as_usize()..(entry.name_start + entry.name_len).as_usize()],
+            data: &self.rom
+                [entry.data_start.as_usize()..(entry.data_start + entry.data_len).as_usize()],
+            r#type: entry.entry_type,
+            offset: entry.data_start,
+        }))
+    }
+}
+
+impl<'a> CbfsReader<'a> {
+    /// Open an existing CBFS image.
+    ///
+    /// `rom_base` is the absolute address where the ROM is mapped (e.g.
+    /// `0xFFC00000` for a 4MB ROM).
+    pub fn open(rom: &'a [u8], rom_base: u32) -> Result<Self, CbfsError> {
+        let (_, align, offset) = parse_header(rom, rom_base)?;
+        Ok(Self { rom, align, offset })
+    }
+
+    /// Return an iterator over all file entries in the image.
+    pub fn files(&self) -> CbfsFiles<'a> {
+        CbfsFiles {
+            rom: self.rom,
+            walker: CbfsEntryWalker::new(self.align, self.offset),
+        }
+    }
+
+    /// Find a file by name.
+    ///
+    /// Returns `Ok(None)` if no matching file was found, or
+    /// `Err(CbfsError::CorruptEntry)` if a corrupt entry was encountered
+    /// before the file could be located.
+    pub fn find_file(&self, name: &[u8]) -> Result<Option<CbfsFile<'a>>, CbfsError> {
+        for result in self.files() {
+            let f = result?;
+            if f.r#type != CBFS_TYPE_NULL && f.r#type != CBFS_TYPE_DELETED && f.name == name {
+                return Ok(Some(f));
+            }
+        }
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::cbfs::CbfsWriter;
+
+    const ROM_SIZE: u32 = 4096;
+    const ROM_BASE: u32 = 0xFFFF_F000;
+
+    fn build_test_rom(files: &[(&[u8], u32, &[u8])]) -> Vec<u8> {
+        let mut rom = vec![0xFFu8; ROM_SIZE.as_usize()];
+        {
+            let mut writer =
+                CbfsWriter::create(&mut rom, ROM_BASE, CBFS_DEFAULT_ALIGNMENT).unwrap();
+            for &(name, r#type, data) in files {
+                writer.add_file(None, name, r#type, data).unwrap();
+            }
+        }
+        rom
+    }
+
+    #[test]
+    fn test_open_and_iterate() {
+        let rom = build_test_rom(&[]);
+        let cbfs = CbfsReader::open(&rom, ROM_BASE).unwrap();
+        assert_eq!(cbfs.files().count(), 2); // master header + NULL
+
+        let rom = build_test_rom(&[
+            (b"file/one", CBFS_TYPE_RAW, b"first"),
+            (b"file/two", CBFS_TYPE_RAW, b"second"),
+        ]);
+        let cbfs = CbfsReader::open(&rom, ROM_BASE).unwrap();
+        let names: Vec<_> = cbfs.files().map(|f| f.unwrap().name).collect();
+        assert_eq!(
+            names,
+            &[
+                b"cbfs_master_header".as_ref(),
+                b"file/one",
+                b"file/two",
+                b"",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_find_file() {
+        let rom = build_test_rom(&[
+            (b"null", CBFS_TYPE_NULL, b"x"),
+            (b"deleted", CBFS_TYPE_DELETED, b"x"),
+            (b"test/hello", CBFS_TYPE_RAW, b"Hello CBFS!"),
+        ]);
+        let cbfs = CbfsReader::open(&rom, ROM_BASE).unwrap();
+
+        let file = cbfs.find_file(b"test/hello").unwrap().unwrap();
+        assert_eq!(file.name, b"test/hello");
+        assert_eq!(file.data, b"Hello CBFS!");
+        assert_eq!(file.r#type, CBFS_TYPE_RAW);
+
+        // Skips NULL/DELETED types and missing names
+        assert!(cbfs.find_file(b"null").unwrap().is_none());
+        assert!(cbfs.find_file(b"deleted").unwrap().is_none());
+        assert!(cbfs.find_file(b"nonexistent").unwrap().is_none());
+    }
+}

--- a/lace-util/src/cbfs/writer.rs
+++ b/lace-util/src/cbfs/writer.rs
@@ -1,0 +1,465 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+// Copyright (C) 2026, Canonical Ltd.
+// Authors: Mate Kukri <mate.kukri@canonical.com>
+
+//! CBFS image writer.
+//!
+//! Free space in a CBFS image is represented as `CBFS_TYPE_NULL` entries.
+//! Adding a file finds a suitable NULL slot and splits it; deleting a file
+//! marks it as `CBFS_TYPE_DELETED` and merges adjacent empty entries, matching
+//! the semantics of coreboot's cbfstool.
+
+use zerocopy::byteorder::{LE, U32};
+use zerocopy::{FromBytes, IntoBytes};
+
+use super::r#priv::{CbfsEntryWalker, parse_header};
+use super::*;
+use crate::{UsizeIsAtLeastU32, align_up_checked, const_u32};
+
+/// Minimum metadata size: header + one NUL byte for an empty name.
+const MIN_ENTRY_METADATA: u32 = const_u32(size_of::<CbfsFileHeader>() + 1);
+
+/// A CBFS image writer operating on a caller-provided ROM buffer.
+///
+/// Can initialize a fresh image or open an existing one for modification.
+/// Free space is tracked as `CBFS_TYPE_NULL` entries; no append cursor is
+/// needed. All operations use checked arithmetic and bounds validation.
+pub struct CbfsWriter<'a> {
+    rom: &'a mut [u8],
+    align: u32,
+    offset: u32,
+}
+
+impl<'a> CbfsWriter<'a> {
+    /// Initialize a fresh CBFS image in `rom`.
+    ///
+    /// Fills `rom` with `0xFF`, writes the master header as the first file
+    /// entry, and creates a single large `CBFS_TYPE_NULL` entry covering all
+    /// remaining space. The header pointer is written at the last 4 bytes.
+    pub fn create(rom: &'a mut [u8], rom_base: u32, align: u32) -> Result<Self, CbfsError> {
+        let rom_size: u32 = rom
+            .len()
+            .try_into()
+            .ok()
+            .filter(|s: &u32| s.is_power_of_two())
+            .ok_or(CbfsError::InvalidRomSize)?;
+
+        if !rom_base.is_multiple_of(rom_size) {
+            return Err(CbfsError::InvalidRomBase);
+        }
+        if !align.is_power_of_two() || align > rom_size {
+            return Err(CbfsError::InvalidAlignment);
+        }
+
+        rom.fill(0xFF);
+
+        let mut writer = Self {
+            rom,
+            align,
+            offset: 0,
+        };
+
+        // Write master header as the first file entry
+        let header = CbfsHeader {
+            magic: CBFS_HEADER_MAGIC.into(),
+            version: CBFS_HEADER_VERSION2.into(),
+            romsize: rom_size.into(),
+            bootblocksize: 4.into(),
+            align: align.into(),
+            offset: 0.into(),
+            architecture: CBFS_ARCHITECTURE_X86.into(),
+            _pad: 0.into(),
+        };
+        let name = b"cbfs_master_header";
+        let data = header.as_bytes();
+        let data_len = const_u32(size_of::<CbfsHeader>());
+        let data_offset = const_u32(size_of::<CbfsFileHeader>() + name.len() + 1);
+        writer.write_entry(0, name, CBFS_TYPE_RAW, data, data_len, data_offset);
+
+        // Write master header pointer at last 4 bytes
+        let ptr: U32<LE> = rom_base
+            .checked_add(data_offset)
+            .ok_or(CbfsError::InvalidRomBase)?
+            .into();
+        ptr.write_to_suffix(writer.rom)
+            .map_err(|_| CbfsError::InvalidRomSize)?;
+
+        // Create a NULL entry spanning all remaining space before the
+        // 4-byte header pointer at the end of the ROM.
+        let null_start =
+            align_up_checked!(data_offset + data_len, align).ok_or(CbfsError::InvalidRomSize)?;
+        let entries_end = rom_size.checked_sub(4).ok_or(CbfsError::InvalidRomSize)?;
+        if entries_end > null_start + MIN_ENTRY_METADATA {
+            let null_len = entries_end - null_start - MIN_ENTRY_METADATA;
+            writer.write_null_entry(null_start, null_len);
+        }
+
+        Ok(writer)
+    }
+
+    /// Open an existing CBFS image for modification.
+    pub fn open(rom: &'a mut [u8], rom_base: u32) -> Result<Self, CbfsError> {
+        let (_, align, offset) = parse_header(rom, rom_base)?;
+        Ok(Self { rom, align, offset })
+    }
+
+    /// Append a file to the CBFS.
+    ///
+    /// Walks entries looking for a `CBFS_TYPE_NULL` slot large enough to
+    /// hold the new file. If `content_offset` is specified, the file data
+    /// must begin at that ROM offset. Merges adjacent empty entries before
+    /// searching (matching cbfstool semantics).
+    pub fn add_file(
+        &mut self,
+        content_offset: Option<u32>,
+        name: &[u8],
+        r#type: u32,
+        data: &[u8],
+    ) -> Result<(), CbfsError> {
+        if name.contains(&0) {
+            return Err(CbfsError::NulInName);
+        }
+
+        let data_len: u32 = data.len().try_into().map_err(|_| CbfsError::TooLarge)?;
+        let name_len: u32 = name.len().try_into().map_err(|_| CbfsError::TooLarge)?;
+
+        self.merge_empty_entries()?;
+
+        let hdr_size = const_u32(size_of::<CbfsFileHeader>());
+        let header_size = align_up_checked!(
+            hdr_size
+                .checked_add(name_len)
+                .and_then(|n| n.checked_add(1))
+                .ok_or(CbfsError::TooLarge)?,
+            self.align
+        )
+        .ok_or(CbfsError::TooLarge)?;
+        let need_size = header_size
+            .checked_add(data_len)
+            .ok_or(CbfsError::TooLarge)?;
+
+        // Walk entries looking for a suitable NULL slot
+        let mut walker = CbfsEntryWalker::new(self.align, self.offset);
+        while let Some(result) = walker.next(self.rom) {
+            let entry = result?;
+            let slot_size = entry.entry_end - entry.entry_start;
+
+            if entry.entry_type != CBFS_TYPE_NULL || slot_size < need_size {
+                continue;
+            }
+
+            // Check content_offset constraints
+            if let Some(co) = content_offset {
+                let co_end = co.checked_add(data_len).ok_or(CbfsError::TooLarge)?;
+                if co < entry.entry_start + header_size || co_end > entry.entry_end {
+                    continue;
+                }
+            }
+
+            let co = content_offset.unwrap_or(entry.entry_start + header_size);
+            let co_end = co.checked_add(data_len).ok_or(CbfsError::TooLarge)?;
+            let new_entry_start = (co - header_size) & !(self.align - 1);
+
+            // Leading gap: create a NULL entry if big enough
+            let min_aligned =
+                align_up_checked!(MIN_ENTRY_METADATA, self.align).ok_or(CbfsError::TooLarge)?;
+            if new_entry_start > entry.entry_start {
+                let leading = new_entry_start - entry.entry_start;
+                if leading >= min_aligned {
+                    let null_len = leading - MIN_ENTRY_METADATA;
+                    self.write_null_entry(entry.entry_start, null_len);
+                }
+            }
+
+            // Write the file entry
+            let hdr_start = new_entry_start.max(entry.entry_start);
+            let data_offset = co - hdr_start;
+            self.write_entry(hdr_start, name, r#type, data, data_len, data_offset);
+
+            // Trailing gap: create a NULL entry if big enough
+            let file_end = align_up_checked!(co_end, self.align).ok_or(CbfsError::TooLarge)?;
+            if entry.entry_end > file_end {
+                let trailing = entry.entry_end - file_end;
+                if trailing >= min_aligned {
+                    let null_len = trailing - MIN_ENTRY_METADATA;
+                    self.write_null_entry(file_end, null_len);
+                }
+            }
+
+            return Ok(());
+        }
+
+        Err(CbfsError::NoSpace)
+    }
+
+    /// Delete the file with the given name.
+    ///
+    /// Marks the entry as `CBFS_TYPE_DELETED` and merges adjacent empty
+    /// entries. Returns `Ok(true)` if found and deleted, `Ok(false)` if
+    /// not found.
+    ///
+    /// Note: if a corrupt entry is encountered before the file is found,
+    /// `Err(CbfsError::CorruptEntry)` is returned and the image may have
+    /// been partially modified by a preceding merge pass.
+    pub fn delete_file(&mut self, name: &[u8]) -> Result<bool, CbfsError> {
+        let mut walker = CbfsEntryWalker::new(self.align, self.offset);
+        while let Some(result) = walker.next(self.rom) {
+            let entry = result?;
+            if &self.rom
+                [entry.name_start.as_usize()..(entry.name_start + entry.name_len).as_usize()]
+                == name
+            {
+                let (hdr, _) =
+                    CbfsFileHeader::mut_from_prefix(&mut self.rom[entry.entry_start.as_usize()..])
+                        .expect("unreachable");
+                hdr.r#type = CBFS_TYPE_DELETED.into();
+                self.merge_empty_entries()?;
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    /// Merge consecutive NULL/DELETED entries into single NULL entries.
+    ///
+    /// Returns `Err(CbfsError::CorruptEntry)` if a corrupt entry is
+    /// encountered; entries before the corrupt one may already have been
+    /// merged.
+    fn merge_empty_entries(&mut self) -> Result<(), CbfsError> {
+        let mut walker = CbfsEntryWalker::new(self.align, self.offset);
+        while let Some(result) = walker.next(self.rom) {
+            let entry = result?;
+            if entry.entry_type != CBFS_TYPE_NULL && entry.entry_type != CBFS_TYPE_DELETED {
+                continue;
+            }
+
+            // Walk forward, absorbing consecutive empty entries
+            let mut merge_end = entry.entry_end;
+            let mut inner = CbfsEntryWalker::new(
+                self.align,
+                align_up_checked!(merge_end, self.align).ok_or(CbfsError::CorruptEntry)?,
+            );
+            while let Some(result) = inner.next(self.rom) {
+                let next = result?;
+                if next.entry_type != CBFS_TYPE_NULL && next.entry_type != CBFS_TYPE_DELETED {
+                    break;
+                }
+                merge_end = next.entry_end;
+            }
+
+            if merge_end > entry.entry_end {
+                let null_len = merge_end - entry.entry_start - MIN_ENTRY_METADATA;
+                self.write_null_entry(entry.entry_start, null_len);
+            }
+        }
+        Ok(())
+    }
+
+    /// Write a file entry (header + NUL-terminated name + data) at
+    /// `entry_start`. `data_offset` is the distance from `entry_start`
+    /// to the data. `data_len` is the content length stored in the
+    /// header (must equal `data.len()` or be larger for NULL padding).
+    ///
+    /// # Panics
+    ///
+    /// Panics if offsets are out of bounds. Callers must validate
+    /// placement before calling.
+    fn write_entry(
+        &mut self,
+        entry_start: u32,
+        name: &[u8],
+        r#type: u32,
+        data: &[u8],
+        data_len: u32,
+        data_offset: u32,
+    ) {
+        let hdr = CbfsFileHeader {
+            magic: CBFS_FILE_MAGIC,
+            len: data_len.into(),
+            r#type: r#type.into(),
+            attributes_offset: 0.into(),
+            offset: data_offset.into(),
+        };
+
+        let start = entry_start.as_usize();
+        let hdr_end = start + size_of::<CbfsFileHeader>();
+        let name_end = hdr_end + name.len();
+        let data_start = start + data_offset.as_usize();
+        let data_end = data_start + data.len();
+
+        self.rom[start..hdr_end].copy_from_slice(hdr.as_bytes());
+        self.rom[hdr_end..name_end].copy_from_slice(name);
+        self.rom[name_end] = 0;
+        self.rom[data_start..data_end].copy_from_slice(data);
+    }
+
+    /// Write a NULL (free space) entry at `start` with the given content
+    /// length.
+    ///
+    /// # Panics
+    ///
+    /// Panics if offsets are out of bounds. Callers must validate
+    /// placement before calling.
+    fn write_null_entry(&mut self, start: u32, len: u32) {
+        self.write_entry(start, b"", CBFS_TYPE_NULL, &[], len, MIN_ENTRY_METADATA);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::cbfs::CbfsReader;
+
+    const ROM_SIZE: u32 = 4096;
+    const ROM_BASE: u32 = 0xFFFF_F000;
+
+    fn new_image() -> Vec<u8> {
+        let mut rom = vec![0u8; ROM_SIZE.as_usize()];
+        CbfsWriter::create(&mut rom, ROM_BASE, CBFS_DEFAULT_ALIGNMENT).unwrap();
+        rom
+    }
+
+    #[test]
+    fn test_create_roundtrip() {
+        let mut rom = new_image();
+        {
+            let mut w = CbfsWriter::open(&mut rom, ROM_BASE).unwrap();
+            w.add_file(None, b"hello", CBFS_TYPE_RAW, b"world").unwrap();
+            // Place a file at a specific content offset (leading gap path)
+            w.add_file(Some(ROM_SIZE - 128), b"placed", CBFS_TYPE_RAW, b"here")
+                .unwrap();
+        }
+
+        let reader = CbfsReader::open(&rom, ROM_BASE).unwrap();
+        assert_eq!(reader.find_file(b"hello").unwrap().unwrap().data, b"world");
+        assert_eq!(reader.find_file(b"placed").unwrap().unwrap().data, b"here");
+    }
+
+    #[test]
+    fn test_create_rejects_bad_alignment() {
+        let mut rom = vec![0u8; ROM_SIZE.as_usize()];
+        assert!(matches!(
+            CbfsWriter::create(&mut rom, ROM_BASE, 3),
+            Err(CbfsError::InvalidAlignment)
+        ));
+    }
+
+    #[test]
+    fn test_create_rejects_alignment_larger_than_rom() {
+        let mut rom = vec![0u8; ROM_SIZE.as_usize()];
+        assert!(matches!(
+            CbfsWriter::create(&mut rom, ROM_BASE, ROM_SIZE * 2),
+            Err(CbfsError::InvalidAlignment)
+        ));
+    }
+
+    #[test]
+    fn test_open_and_append() {
+        let mut rom = new_image();
+        CbfsWriter::open(&mut rom, ROM_BASE)
+            .unwrap()
+            .add_file(None, b"first", CBFS_TYPE_RAW, b"1")
+            .unwrap();
+        CbfsWriter::open(&mut rom, ROM_BASE)
+            .unwrap()
+            .add_file(None, b"second", CBFS_TYPE_RAW, b"2")
+            .unwrap();
+
+        let reader = CbfsReader::open(&rom, ROM_BASE).unwrap();
+        assert_eq!(reader.find_file(b"first").unwrap().unwrap().data, b"1");
+        assert_eq!(reader.find_file(b"second").unwrap().unwrap().data, b"2");
+    }
+
+    #[test]
+    fn test_delete_file() {
+        let mut rom = new_image();
+        {
+            let mut w = CbfsWriter::open(&mut rom, ROM_BASE).unwrap();
+            w.add_file(None, b"keep", CBFS_TYPE_RAW, b"yes").unwrap();
+            w.add_file(None, b"remove", CBFS_TYPE_RAW, b"no").unwrap();
+        }
+        {
+            let mut w = CbfsWriter::open(&mut rom, ROM_BASE).unwrap();
+            assert_eq!(w.delete_file(b"remove"), Ok(true));
+            assert_eq!(w.delete_file(b"nonexistent"), Ok(false));
+        }
+
+        let reader = CbfsReader::open(&rom, ROM_BASE).unwrap();
+        assert_eq!(reader.find_file(b"keep").unwrap().unwrap().data, b"yes");
+        assert!(reader.find_file(b"remove").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_delete_and_reuse_space() {
+        let mut rom = new_image();
+        {
+            let mut w = CbfsWriter::open(&mut rom, ROM_BASE).unwrap();
+            w.add_file(None, b"a", CBFS_TYPE_RAW, b"aaaa").unwrap();
+            w.add_file(None, b"b", CBFS_TYPE_RAW, b"bbbb").unwrap();
+            w.add_file(None, b"c", CBFS_TYPE_RAW, b"cccc").unwrap();
+        }
+        {
+            let mut w = CbfsWriter::open(&mut rom, ROM_BASE).unwrap();
+            assert_eq!(w.delete_file(b"b"), Ok(true));
+            w.add_file(None, b"d", CBFS_TYPE_RAW, b"dd").unwrap();
+        }
+
+        let reader = CbfsReader::open(&rom, ROM_BASE).unwrap();
+        assert_eq!(reader.find_file(b"a").unwrap().unwrap().data, b"aaaa");
+        assert!(reader.find_file(b"b").unwrap().is_none());
+        assert_eq!(reader.find_file(b"c").unwrap().unwrap().data, b"cccc");
+        assert_eq!(reader.find_file(b"d").unwrap().unwrap().data, b"dd");
+    }
+
+    #[test]
+    fn test_delete_adjacent_merges() {
+        let mut rom = new_image();
+        let large_data = vec![0x42u8; 256];
+        {
+            let mut w = CbfsWriter::open(&mut rom, ROM_BASE).unwrap();
+            w.add_file(None, b"a", CBFS_TYPE_RAW, b"aa").unwrap();
+            w.add_file(None, b"b", CBFS_TYPE_RAW, b"bb").unwrap();
+            w.add_file(None, b"c", CBFS_TYPE_RAW, b"cc").unwrap();
+        }
+        {
+            let mut w = CbfsWriter::open(&mut rom, ROM_BASE).unwrap();
+            assert_eq!(w.delete_file(b"a"), Ok(true));
+            assert_eq!(w.delete_file(b"b"), Ok(true));
+            w.add_file(None, b"big", CBFS_TYPE_RAW, &large_data)
+                .unwrap();
+        }
+
+        let reader = CbfsReader::open(&rom, ROM_BASE).unwrap();
+        assert_eq!(
+            reader.find_file(b"big").unwrap().unwrap().data,
+            &large_data[..]
+        );
+        assert_eq!(reader.find_file(b"c").unwrap().unwrap().data, b"cc");
+    }
+
+    #[test]
+    fn test_add_file_rejects_invalid() {
+        let mut rom = new_image();
+        let mut w = CbfsWriter::open(&mut rom, ROM_BASE).unwrap();
+        // NUL in name
+        assert!(matches!(
+            w.add_file(None, b"bad\0name", CBFS_TYPE_RAW, b"x"),
+            Err(CbfsError::NulInName)
+        ));
+        // Data too large for ROM
+        assert!(matches!(
+            w.add_file(
+                None,
+                b"huge",
+                CBFS_TYPE_RAW,
+                &vec![0u8; ROM_SIZE.as_usize()]
+            ),
+            Err(CbfsError::NoSpace)
+        ));
+        // content_offset too early (no room for header)
+        assert!(matches!(
+            w.add_file(Some(0), b"bad", CBFS_TYPE_RAW, b"x"),
+            Err(CbfsError::NoSpace)
+        ));
+    }
+}

--- a/lace-util/src/lib.rs
+++ b/lace-util/src/lib.rs
@@ -9,6 +9,7 @@ extern crate alloc;
 #[cfg(feature = "firmware")]
 pub mod acpi;
 pub mod bls;
+pub mod cbfs;
 pub mod chid;
 pub mod chid_mapping;
 pub mod chid_matcher;

--- a/lace-util/src/lib.rs
+++ b/lace-util/src/lib.rs
@@ -67,6 +67,20 @@ macro_rules! align_up {
     }};
 }
 
+/// Align `value` up to `alignment`, returning `None` on overflow or if
+/// `alignment` is zero.
+#[macro_export]
+macro_rules! align_up_checked {
+    ($val:expr, $align:expr $(,)?) => {{
+        let align = $align;
+        if align == 0 {
+            None
+        } else {
+            ($val).checked_add(align - 1).map(|v| v / align * align)
+        }
+    }};
+}
+
 #[macro_export]
 macro_rules! align_down {
     ($val:expr, $bound:expr $(,)?) => {{
@@ -87,6 +101,38 @@ macro_rules! count_blocks_aligned_down {
     ($val:expr, $block_size:expr $(,)?) => {
         $val / $block_size
     };
+}
+
+/// Infallible `u32` → `usize` widening on 32-bit and 64-bit targets.
+///
+/// Provides `.as_usize()` on `u32` so that index expressions read
+/// naturally without `as` casts.  The trait (and the crate) simply
+/// will not compile on a hypothetical 16-bit target where the
+/// conversion would be lossy.
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
+pub trait UsizeIsAtLeastU32 {
+    /// Widen to `usize` (infallible on 32- and 64-bit platforms).
+    #[allow(clippy::wrong_self_convention)]
+    fn as_usize(self) -> usize;
+}
+
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
+impl UsizeIsAtLeastU32 for u32 {
+    #[inline(always)]
+    fn as_usize(self) -> usize {
+        self as usize
+    }
+}
+
+/// Convert a `usize` to `u32`, panic if the value exceeds `u32::MAX`.
+///
+/// This is intended for use in `const` contexts -- where it will be
+/// evaluated at compile-time, and fail to compile if the value exceeds
+/// `u32::MAX`.
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
+pub const fn const_u32(v: usize) -> u32 {
+    assert!(v <= u32::MAX as usize);
+    v as u32
 }
 
 #[repr(C)]
@@ -375,6 +421,18 @@ mod test {
         assert_eq!(align_up!(12u32, 4u32), 12);
         assert_eq!(align_up!(0u32, 4u32), 0);
         assert_eq!(align_up!(1u32, 1u32), 1);
+    }
+
+    #[test]
+    fn test_align_up_checked() {
+        assert_eq!(align_up_checked!(10usize, 4usize), Some(12));
+        assert_eq!(align_up_checked!(12usize, 4usize), Some(12));
+        assert_eq!(align_up_checked!(0usize, 4usize), Some(0));
+        assert_eq!(align_up_checked!(1usize, 1usize), Some(1));
+        assert_eq!(align_up_checked!(usize::MAX, 2usize), None);
+        // Also works with u32
+        assert_eq!(align_up_checked!(10u32, 4u32), Some(12u32));
+        assert_eq!(align_up_checked!(u32::MAX, 2u32), None);
     }
 
     #[test]

--- a/tools/flashedit/Cargo.toml
+++ b/tools/flashedit/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "flashedit"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+clap.workspace = true
+lace-util = { path = "../../lace-util", default-features = false }

--- a/tools/flashedit/src/main.rs
+++ b/tools/flashedit/src/main.rs
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+// Copyright (C) 2026, Canonical Ltd.
+// Authors: Mate Kukri <mate.kukri@canonical.com>
+
+//! flashedit: Build and manipulate CBFS flash images
+
+use clap::{Parser, Subcommand};
+use lace_util::UsizeIsAtLeastU32;
+use lace_util::cbfs::*;
+use std::path::PathBuf;
+use std::{fs, process};
+
+#[derive(Parser)]
+#[command(name = "flashedit", about = "Build and manipulate CBFS flash images")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Create a new CBFS flash image
+    Create {
+        /// Output file path
+        #[arg(short, long)]
+        output: PathBuf,
+        /// ROM size in bytes (e.g. 65536 for 64K, or use suffixes like 64K, 1M)
+        #[arg(short, long, value_parser = parse_size)]
+        size: u32,
+        /// Bootblock flat binary file
+        #[arg(short, long)]
+        bootblock: PathBuf,
+        /// Files to add: name=path pairs (e.g. firmware=firmware.elf)
+        #[arg(short, long = "file", value_parser = parse_file_arg)]
+        files: Vec<(String, PathBuf)>,
+    },
+    /// List files in a CBFS image
+    List {
+        /// Input CBFS image file
+        #[arg(short, long)]
+        input: PathBuf,
+    },
+}
+
+/// Parses a ROM size, supporting suffixes K, M, G, ensuring minimum size of 4 bytes.
+fn parse_size(s: &str) -> Result<u32, String> {
+    let mut s = s.trim();
+    let mut mul = 1u32;
+    for (suf_str, suf_mul) in [("K", 1024), ("M", 1024 * 1024), ("G", 1024 * 1024 * 1024)] {
+        if let Some(prefix) = s.strip_suffix(suf_str) {
+            s = prefix.trim();
+            mul = suf_mul;
+            break;
+        }
+    }
+    s.parse::<u32>()
+        .ok()
+        .and_then(|x| x.checked_mul(mul))
+        .and_then(|x| if x >= 4 { Some(x) } else { None })
+        .ok_or_else(|| format!("Invalid size {}", s))
+}
+
+fn parse_file_arg(s: &str) -> Result<(String, PathBuf), String> {
+    let (name, path) = s.split_once('=').ok_or("expected name=path")?;
+    if name.is_empty() {
+        return Err("file name must not be empty".into());
+    }
+    if name.contains('\0') {
+        return Err(format!(
+            "file name '{}' contains NUL; CBFS names are NUL-terminated on flash",
+            name.escape_debug()
+        ));
+    }
+    Ok((name.to_string(), PathBuf::from(path)))
+}
+
+fn cmd_create(
+    output: PathBuf,
+    rom_size: u32,
+    bootblock: PathBuf,
+    files: Vec<(String, PathBuf)>,
+) -> Result<(), String> {
+    let bb_data = fs::read(&bootblock)
+        .map_err(|e| format!("failed to read bootblock {}: {}", bootblock.display(), e))?;
+
+    if bb_data.len() > rom_size.as_usize() {
+        return Err(format!(
+            "bootblock ({} bytes) exceeds ROM size ({} bytes)",
+            bb_data.len(),
+            rom_size
+        ));
+    }
+
+    let rom_base: u32 = 0u32.wrapping_sub(rom_size);
+
+    let mut rom = vec![0u8; rom_size.as_usize()];
+    {
+        let mut writer = CbfsWriter::create(&mut rom, rom_base, CBFS_DEFAULT_ALIGNMENT)
+            .map_err(|e| format!("failed to create CBFS image: {e}"))?;
+
+        // Add user files
+        for (name, path) in &files {
+            let data =
+                fs::read(path).map_err(|e| format!("failed to read {}: {}", path.display(), e))?;
+            eprintln!("  {:40} size={}", name, data.len());
+            writer
+                .add_file(None, name.as_bytes(), CBFS_TYPE_RAW, &data)
+                .map_err(|e| format!("failed to add file '{}': {e}", name))?;
+        }
+
+        // Add bootblock at top of ROM, leaving the last 4 bytes for
+        // the CBFS header pointer which is written over the bootblock.
+        if bb_data.len() < 4 {
+            return Err("bootblock must be at least 4 bytes".into());
+        }
+        let bb_trimmed = &bb_data[..bb_data.len() - 4];
+        let bb_content_offset =
+            rom_size - u32::try_from(bb_data.len()).map_err(|_| "bootblock too large")?;
+        eprintln!(
+            "  {:40} offset={:#010x} size={}",
+            "bootblock",
+            bb_content_offset,
+            bb_data.len()
+        );
+        writer
+            .add_file(
+                Some(bb_content_offset),
+                b"bootblock",
+                CBFS_TYPE_BOOTBLOCK,
+                bb_trimmed,
+            )
+            .map_err(|e| format!("failed to add bootblock: {e}"))?;
+    }
+
+    fs::write(&output, &rom).map_err(|e| format!("failed to write {}: {}", output.display(), e))?;
+    eprintln!(
+        "Created CBFS image {} ({} bytes)",
+        output.display(),
+        rom_size
+    );
+    Ok(())
+}
+
+fn cmd_list(input: PathBuf) -> Result<(), String> {
+    let rom = fs::read(&input).map_err(|e| format!("failed to read {}: {}", input.display(), e))?;
+
+    let size = rom.len();
+    let rom_size = u32::try_from(size).ok().filter(|_| size >= 4);
+    let Some(rom_size) = rom_size else {
+        return Err(format!(
+            "ROM size ({}) is not a valid CBFS image size",
+            size
+        ));
+    };
+
+    let rom_base: u32 = 0u32.wrapping_sub(rom_size);
+    let reader =
+        CbfsReader::open(&rom, rom_base).map_err(|e| format!("failed to open CBFS image: {e}"))?;
+
+    println!(
+        "{:40} {:>10} {:>10} {:>10}",
+        "Name", "Data Offset", "Size", "Type"
+    );
+    println!("{}", "-".repeat(74));
+
+    for result in reader.files() {
+        let file = result.map_err(|e| format!("corrupt CBFS entry: {e}"))?;
+        let name = std::str::from_utf8(file.name).unwrap_or("???");
+        let type_str = match file.r#type {
+            CBFS_TYPE_NULL => "(empty)",
+            CBFS_TYPE_BOOTBLOCK => "bootblock",
+            CBFS_TYPE_RAW => "raw",
+            CBFS_TYPE_DELETED => "deleted",
+            _ => "unknown",
+        };
+        println!(
+            "{:40} {:#010x} {:>10} {:>10}",
+            name,
+            file.offset,
+            file.data.len(),
+            type_str
+        );
+    }
+
+    Ok(())
+}
+
+fn main() {
+    let cli = Cli::parse();
+    let result = match cli.command {
+        Command::Create {
+            output,
+            size,
+            bootblock,
+            files,
+        } => cmd_create(output, size, bootblock, files),
+        Command::List { input } => cmd_list(input),
+    };
+    if let Err(e) = result {
+        eprintln!("flashedit: {}", e);
+        process::exit(1);
+    }
+}


### PR DESCRIPTION
CBFS is a simple flash "filesystem" orignating for coreboot for storing a sequence of easy to parse entries inside a flash image. While lace VM firmware is not using any coreboot code, we are re-using this format in lace firmware because it's very simple and already does everything we want.

This commit adds a clean CBFS reader and writer in lace-util, and a new tool flashedit for creating CBFS images. The parser and writer is hardened against invalid input for integer overflows as much as realistic and has high test branch coverage.