### PR TITLE
Add riscv64 EFI builds for stubble/speedboot

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ to the Canonical CLA. See the file `CONTRIBUTING.md` for details.
 
 You may want to use development tools:
 * `scripts/vm_manage.py` - a helper tool to setup and run test VMs
+* `scripts/build_efi.py` - builds EFI binaries for Lace applications
 * `tools/fakeedid` - a helper tool to fake some EDID data in a test VM
 
 # Discussions

--- a/scripts/build_efi.py
+++ b/scripts/build_efi.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
+# Copyright (C) 2026, Canonical Ltd.
+
+"""Build Lace EFI binaries for supported architectures."""
+
+import argparse
+import os
+import subprocess
+
+
+RISCV_TARGET = "riscv64imac-unknown-none-elf"
+RISCV_BUILD_STD = "build-std=core,alloc,compiler_builtins"
+RISCV_BUILD_STD_FEATURES = "build-std-features=mem"
+
+
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Build EFI binary for Lace package")
+    parser.add_argument(
+        "--package", required=True, choices=["lace-stubble", "lace-speedboot"]
+    )
+    parser.add_argument(
+        "--arch", required=True, choices=["x86_64", "aarch64", "riscv64"]
+    )
+    parser.add_argument(
+        "--profile", default="debug", choices=["debug", "release"], help="Build profile"
+    )
+    return parser.parse_args()
+
+
+def efi_target(arch):
+    """Return the build target triple for an architecture."""
+    if arch == "riscv64":
+        return RISCV_TARGET
+    return f"{arch}-unknown-uefi"
+
+
+def efi_output_path(package, arch, profile):
+    """Return the expected EFI output path for a build."""
+    target = efi_target(arch)
+    profile_dir = "release" if profile == "release" else "debug"
+    return os.path.join("target", target, profile_dir, f"{package}.efi")
+
+
+def build_native_uefi(package, arch, profile):
+    """Build an EFI binary through rustc's native UEFI targets."""
+    cmd = [
+        "cargo",
+        "build",
+        "-p",
+        package,
+        "--no-default-features",
+        "--features",
+        "efi",
+        "--target",
+        efi_target(arch),
+    ]
+    if profile == "release":
+        cmd.append("--release")
+    subprocess.run(cmd, check=True)
+
+
+def build_riscv_elf(package, profile):
+    """Build a RISC-V PIE ELF image suitable for PE conversion."""
+    env = os.environ.copy()
+    riscv_rustflags = " ".join(
+        [
+            "-C relocation-model=pie",
+            "-C link-arg=-pie",
+            "-C link-arg=--entry=efi_main",
+            "-C link-arg=-z",
+            "-C link-arg=common-page-size=4096",
+            "-C link-arg=-z",
+            "-C link-arg=max-page-size=4096",
+            "-C link-arg=-z",
+            "-C link-arg=noexecstack",
+            "-C link-arg=-z",
+            "-C link-arg=relro",
+            "-C link-arg=-z",
+            "-C link-arg=separate-code",
+        ]
+    )
+    current = env.get("CARGO_TARGET_RISCV64IMAC_UNKNOWN_NONE_ELF_RUSTFLAGS", "")
+    env["CARGO_TARGET_RISCV64IMAC_UNKNOWN_NONE_ELF_RUSTFLAGS"] = (
+        f"{current} {riscv_rustflags}".strip()
+    )
+    env["RUSTC_BOOTSTRAP"] = "1"
+
+    cmd = [
+        "cargo",
+        "build",
+        "-Z",
+        RISCV_BUILD_STD,
+        "-Z",
+        RISCV_BUILD_STD_FEATURES,
+        "-p",
+        package,
+        "--no-default-features",
+        "--features",
+        "efi",
+        "--target",
+        RISCV_TARGET,
+    ]
+    if profile == "release":
+        cmd.append("--release")
+    subprocess.run(cmd, check=True, env=env)
+
+
+def convert_riscv_to_efi(package, profile):
+    """Convert the built RISC-V ELF image into a PE/EFI binary."""
+    profile_dir = "release" if profile == "release" else "debug"
+    elf_path = os.path.join("target", RISCV_TARGET, profile_dir, package)
+    if not os.path.exists(elf_path):
+        raise RuntimeError(f"Build failed: {elf_path} not found")
+
+    efi_path = os.path.join("target", RISCV_TARGET, profile_dir, f"{package}.efi")
+    scripts_dir = os.path.dirname(os.path.abspath(__file__))
+    subprocess.run(
+        [
+            "python3",
+            os.path.join(scripts_dir, "elf2efi.py"),
+            "--version-major=6",
+            "--version-minor=16",
+            "--efi-major=1",
+            "--efi-minor=1",
+            "--subsystem=10",
+            "--minimum-sections=2048",
+            "--copy-sections=.sbat",
+            elf_path,
+            efi_path,
+        ],
+        check=True,
+    )
+
+
+def main():
+    """Run the EFI build flow and print resulting output path."""
+    args = parse_args()
+    if args.arch == "riscv64":
+        build_riscv_elf(args.package, args.profile)
+        convert_riscv_to_efi(args.package, args.profile)
+    else:
+        build_native_uefi(args.package, args.arch, args.profile)
+
+    output = efi_output_path(args.package, args.arch, args.profile)
+    if not os.path.exists(output):
+        raise RuntimeError(f"Build failed: {output} not found")
+    print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/elf2efi.py
+++ b/scripts/elf2efi.py
@@ -1,0 +1,719 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# Convert ELF static PIE to PE/EFI image.
+
+# To do so we simply copy desired ELF sections while preserving their memory layout to ensure that
+# code still runs as expected. We then translate ELF relocations to PE relocations so that the EFI
+# loader/firmware can properly load the binary to any address at runtime.
+#
+# To make this as painless as possible we only operate on static PIEs as they should only contain
+# base relocations that are easy to handle as they have a one-to-one mapping to PE relocations.
+#
+# EDK2 does a similar process using their GenFw tool. The main difference is that they use the
+# --emit-relocs linker flag, which emits a lot of different (static) ELF relocation types that have
+# to be handled differently for each architecture and is overall more work than its worth.
+#
+# Note that on arches where binutils has PE support (x86/x86_64 mostly, aarch64 only recently)
+# objcopy can be used to convert ELF to PE. But this will still not convert ELF relocations, making
+# the resulting binary useless. gnu-efi relies on this method and contains a stub that performs the
+# ELF dynamic relocations at runtime.
+
+# pylint: disable=attribute-defined-outside-init
+
+import argparse
+import hashlib
+import io
+import os
+import pathlib
+import sys
+import time
+import typing
+from ctypes import (
+    c_char,
+    c_uint8,
+    c_uint16,
+    c_uint32,
+    c_uint64,
+    LittleEndianStructure,
+    sizeof,
+)
+
+from elftools.elf.constants import SH_FLAGS
+from elftools.elf.elffile import ELFFile
+from elftools.elf.enums import (
+    ENUM_DT_FLAGS_1,
+    ENUM_RELOC_TYPE_AARCH64,
+    ENUM_RELOC_TYPE_ARM,
+    ENUM_RELOC_TYPE_i386,
+    ENUM_RELOC_TYPE_x64,
+)
+from elftools.elf.relocation import (
+    Relocation as ElfRelocation,
+    RelocationTable as ElfRelocationTable,
+)
+
+
+class PeCoffHeader(LittleEndianStructure):
+    _fields_ = (
+        ("Machine",              c_uint16),
+        ("NumberOfSections",     c_uint16),
+        ("TimeDateStamp",        c_uint32),
+        ("PointerToSymbolTable", c_uint32),
+        ("NumberOfSymbols",      c_uint32),
+        ("SizeOfOptionalHeader", c_uint16),
+        ("Characteristics",      c_uint16),
+    )
+
+
+class PeDataDirectory(LittleEndianStructure):
+    _fields_ = (
+        ("VirtualAddress", c_uint32),
+        ("Size",           c_uint32),
+    )
+
+
+class PeRelocationBlock(LittleEndianStructure):
+    _fields_ = (
+        ("PageRVA",   c_uint32),
+        ("BlockSize", c_uint32),
+    )
+
+    def __init__(self, PageRVA: int):
+        super().__init__(PageRVA)
+        self.entries: typing.List[PeRelocationEntry] = []
+
+
+class PeRelocationEntry(LittleEndianStructure):
+    _fields_ = (
+        ("Offset", c_uint16, 12),
+        ("Type",   c_uint16, 4),
+    )
+
+
+class PeOptionalHeaderStart(LittleEndianStructure):
+    _fields_ = (
+        ("Magic",                   c_uint16),
+        ("MajorLinkerVersion",      c_uint8),
+        ("MinorLinkerVersion",      c_uint8),
+        ("SizeOfCode",              c_uint32),
+        ("SizeOfInitializedData",   c_uint32),
+        ("SizeOfUninitializedData", c_uint32),
+        ("AddressOfEntryPoint",     c_uint32),
+        ("BaseOfCode",              c_uint32),
+    )
+
+
+class PeOptionalHeaderMiddle(LittleEndianStructure):
+    _fields_ = (
+        ("SectionAlignment",            c_uint32),
+        ("FileAlignment",               c_uint32),
+        ("MajorOperatingSystemVersion", c_uint16),
+        ("MinorOperatingSystemVersion", c_uint16),
+        ("MajorImageVersion",           c_uint16),
+        ("MinorImageVersion",           c_uint16),
+        ("MajorSubsystemVersion",       c_uint16),
+        ("MinorSubsystemVersion",       c_uint16),
+        ("Win32VersionValue",           c_uint32),
+        ("SizeOfImage",                 c_uint32),
+        ("SizeOfHeaders",               c_uint32),
+        ("CheckSum",                    c_uint32),
+        ("Subsystem",                   c_uint16),
+        ("DllCharacteristics",          c_uint16),
+    )
+
+
+class PeOptionalHeaderEnd(LittleEndianStructure):
+    _fields_ = (
+        ("LoaderFlags",           c_uint32),
+        ("NumberOfRvaAndSizes",   c_uint32),
+        ("ExportTable",           PeDataDirectory),
+        ("ImportTable",           PeDataDirectory),
+        ("ResourceTable",         PeDataDirectory),
+        ("ExceptionTable",        PeDataDirectory),
+        ("CertificateTable",      PeDataDirectory),
+        ("BaseRelocationTable",   PeDataDirectory),
+        ("Debug",                 PeDataDirectory),
+        ("Architecture",          PeDataDirectory),
+        ("GlobalPtr",             PeDataDirectory),
+        ("TLSTable",              PeDataDirectory),
+        ("LoadConfigTable",       PeDataDirectory),
+        ("BoundImport",           PeDataDirectory),
+        ("IAT",                   PeDataDirectory),
+        ("DelayImportDescriptor", PeDataDirectory),
+        ("CLRRuntimeHeader",      PeDataDirectory),
+        ("Reserved",              PeDataDirectory),
+    )
+
+
+class PeOptionalHeader(LittleEndianStructure):
+    pass
+
+
+class PeOptionalHeader32(PeOptionalHeader):
+    _anonymous_ = ("Start", "Middle", "End")
+    _fields_ = (
+        ("Start",              PeOptionalHeaderStart),
+        ("BaseOfData",         c_uint32),
+        ("ImageBase",          c_uint32),
+        ("Middle",             PeOptionalHeaderMiddle),
+        ("SizeOfStackReserve", c_uint32),
+        ("SizeOfStackCommit",  c_uint32),
+        ("SizeOfHeapReserve",  c_uint32),
+        ("SizeOfHeapCommit",   c_uint32),
+        ("End",                PeOptionalHeaderEnd),
+    )
+
+
+class PeOptionalHeader32Plus(PeOptionalHeader):
+    _anonymous_ = ("Start", "Middle", "End")
+    _fields_ = (
+        ("Start",              PeOptionalHeaderStart),
+        ("ImageBase",          c_uint64),
+        ("Middle",             PeOptionalHeaderMiddle),
+        ("SizeOfStackReserve", c_uint64),
+        ("SizeOfStackCommit",  c_uint64),
+        ("SizeOfHeapReserve",  c_uint64),
+        ("SizeOfHeapCommit",   c_uint64),
+        ("End",                PeOptionalHeaderEnd),
+    )
+
+
+class PeSection(LittleEndianStructure):
+    _fields_ = (
+        ("Name",                 c_char * 8),
+        ("VirtualSize",          c_uint32),
+        ("VirtualAddress",       c_uint32),
+        ("SizeOfRawData",        c_uint32),
+        ("PointerToRawData",     c_uint32),
+        ("PointerToRelocations", c_uint32),
+        ("PointerToLinenumbers", c_uint32),
+        ("NumberOfRelocations",  c_uint16),
+        ("NumberOfLinenumbers",  c_uint16),
+        ("Characteristics",      c_uint32),
+    )
+
+    def __init__(self):
+        super().__init__()
+        self.data = bytearray()
+
+
+N_DATA_DIRECTORY_ENTRIES = 16
+
+assert sizeof(PeSection) == 40
+assert sizeof(PeCoffHeader) == 20
+assert sizeof(PeOptionalHeader32) == 224
+assert sizeof(PeOptionalHeader32Plus) == 240
+
+PE_CHARACTERISTICS_RX = 0x60000020  # CNT_CODE|MEM_READ|MEM_EXECUTE
+PE_CHARACTERISTICS_RW = 0xC0000040  # CNT_INITIALIZED_DATA|MEM_READ|MEM_WRITE
+PE_CHARACTERISTICS_R  = 0x40000040  # CNT_INITIALIZED_DATA|MEM_READ
+
+IGNORE_SECTIONS = [
+    ".eh_frame",
+    ".eh_frame_hdr",
+    ".ARM.exidx",
+    ".relro_padding",
+]
+
+IGNORE_SECTION_TYPES = [
+    "SHT_DYNAMIC",
+    "SHT_DYNSYM",
+    "SHT_GNU_ATTRIBUTES",
+    "SHT_GNU_HASH",
+    "SHT_HASH",
+    "SHT_NOTE",
+    "SHT_REL",
+    "SHT_RELA",
+    "SHT_RELR",
+    "SHT_STRTAB",
+    "SHT_SYMTAB",
+]
+
+# EFI mandates 4KiB memory pages.
+SECTION_ALIGNMENT = 4096
+DEFAULT_FILE_ALIGNMENT = 512
+FILE_ALIGNMENT = DEFAULT_FILE_ALIGNMENT
+
+# Nobody cares about DOS headers, so put the PE header right after.
+PE_OFFSET = 64
+PE_MAGIC = b"PE\0\0"
+
+
+def align_to(x: int, align: int) -> int:
+    return (x + align - 1) & ~(align - 1)
+
+
+def align_down(x: int, align: int) -> int:
+    return x & ~(align - 1)
+
+
+def next_section_address(sections: typing.List[PeSection]) -> int:
+    return align_to(sections[-1].VirtualAddress + sections[-1].VirtualSize,
+                    SECTION_ALIGNMENT)
+
+
+class BadSectionError(ValueError):
+    "One of the sections is in a bad state"
+
+
+def iter_copy_sections(elf: ELFFile) -> typing.Iterator[PeSection]:
+    pe_s = None
+
+    # This is essentially the same as copying by ELF load segments, except that we assemble them
+    # manually, so that we can easily strip unwanted sections. We try to only discard things we know
+    # about so that there are no surprises.
+
+    relro = None
+    for elf_seg in elf.iter_segments():
+        if elf_seg["p_type"] == "PT_LOAD" and elf_seg["p_align"] != SECTION_ALIGNMENT:
+            raise BadSectionError(f"ELF segment {elf_seg['p_type']} is not properly aligned"
+                                  f" ({elf_seg['p_align']} != {SECTION_ALIGNMENT})")
+        if elf_seg["p_type"] == "PT_GNU_RELRO":
+            relro = elf_seg
+
+    for elf_s in elf.iter_sections():
+        if (
+            elf_s["sh_flags"] & SH_FLAGS.SHF_ALLOC == 0
+            or elf_s["sh_type"] in IGNORE_SECTION_TYPES
+            or elf_s.name in IGNORE_SECTIONS
+            or elf_s["sh_size"] == 0
+        ):
+            continue
+        if elf_s["sh_type"] not in ["SHT_PROGBITS", "SHT_NOBITS"]:
+            raise BadSectionError(f"Unknown section {elf_s.name} with type {elf_s['sh_type']}")
+        if elf_s.name == '.got':
+            # FIXME: figure out why those sections are inserted
+            print("WARNING: Non-empty .got section", file=sys.stderr)
+
+        if elf_s["sh_flags"] & SH_FLAGS.SHF_EXECINSTR:
+            rwx = PE_CHARACTERISTICS_RX
+        elif elf_s["sh_flags"] & SH_FLAGS.SHF_WRITE:
+            rwx = PE_CHARACTERISTICS_RW
+        else:
+            rwx = PE_CHARACTERISTICS_R
+
+        # PE images are always relro.
+        if relro and relro.section_in_segment(elf_s):
+            rwx = PE_CHARACTERISTICS_R
+
+        if pe_s and pe_s.Characteristics != rwx:
+            yield pe_s
+            pe_s = None
+
+        if pe_s:
+            # Insert padding to properly align the section.
+            pad_len = elf_s["sh_addr"] - pe_s.VirtualAddress - len(pe_s.data)
+            pe_s.data += bytearray(pad_len) + elf_s.data()
+        else:
+            pe_s = PeSection()
+            pe_s.VirtualAddress = elf_s["sh_addr"]
+            pe_s.Characteristics = rwx
+            pe_s.data = elf_s.data()
+
+    if pe_s:
+        yield pe_s
+
+
+def convert_sections(elf: ELFFile, opt: PeOptionalHeader) -> typing.List[PeSection]:
+    last_vma = (0, 0)
+    sections = []
+
+    for pe_s in iter_copy_sections(elf):
+        # Truncate the VMA to the nearest page and insert appropriate padding. This should not
+        # cause any overlap as this is pretty much how ELF *segments* are loaded/mmapped anyways.
+        # The ELF sections inside should also be properly aligned as we reuse the ELF VMA layout
+        # for the PE image.
+        vma = pe_s.VirtualAddress
+        pe_s.VirtualAddress = align_down(vma, SECTION_ALIGNMENT)
+        pe_s.data = bytearray(vma - pe_s.VirtualAddress) + pe_s.data
+
+        pe_s.VirtualSize = len(pe_s.data)
+        pe_s.SizeOfRawData = align_to(len(pe_s.data), FILE_ALIGNMENT)
+        pe_s.Name = {
+            PE_CHARACTERISTICS_RX: b".text",
+            PE_CHARACTERISTICS_RW: b".data",
+            PE_CHARACTERISTICS_R: b".rodata",
+        }[pe_s.Characteristics]
+
+        # This can happen if not building with '-z separate-code'.
+        if pe_s.VirtualAddress < sum(last_vma):
+            raise BadSectionError(f"Section {pe_s.Name.decode()!r} @0x{pe_s.VirtualAddress:x} overlaps"
+                                  f" previous section @0x{last_vma[0]:x}+0x{last_vma[1]:x}=@0x{sum(last_vma):x}")
+        last_vma = (pe_s.VirtualAddress, pe_s.VirtualSize)
+
+        if pe_s.Name == b".text":
+            opt.BaseOfCode = pe_s.VirtualAddress
+            opt.SizeOfCode += pe_s.VirtualSize
+        else:
+            opt.SizeOfInitializedData += pe_s.VirtualSize
+
+        if pe_s.Name == b".data" and isinstance(opt, PeOptionalHeader32):
+            opt.BaseOfData = pe_s.VirtualAddress
+
+        sections.append(pe_s)
+
+    return sections
+
+
+def copy_sections(
+    elf: ELFFile,
+    opt: PeOptionalHeader,
+    input_names: str,
+    sections: typing.List[PeSection],
+):
+    for name in input_names.split(","):
+        elf_s = elf.get_section_by_name(name)
+        if not elf_s:
+            continue
+        if elf_s.data_alignment > 1 and SECTION_ALIGNMENT % elf_s.data_alignment != 0:
+            raise BadSectionError(f"ELF section {name} is not aligned")
+        if elf_s["sh_flags"] & (SH_FLAGS.SHF_EXECINSTR | SH_FLAGS.SHF_WRITE) != 0:
+            raise BadSectionError(f"ELF section {name} is not read-only data")
+
+        pe_s = PeSection()
+        pe_s.Name = name.encode()
+        pe_s.data = elf_s.data()
+        pe_s.VirtualAddress = next_section_address(sections)
+        pe_s.VirtualSize = len(elf_s.data())
+        pe_s.SizeOfRawData = align_to(len(elf_s.data()), FILE_ALIGNMENT)
+        pe_s.Characteristics = PE_CHARACTERISTICS_R
+        opt.SizeOfInitializedData += pe_s.VirtualSize
+        sections.append(pe_s)
+
+
+def apply_elf_relative_relocation(
+    reloc: ElfRelocation,
+    image_base: int,
+    sections: typing.List[PeSection],
+    addend_size: int,
+):
+    [target] = [pe_s for pe_s in sections
+                if pe_s.VirtualAddress <= reloc["r_offset"] < pe_s.VirtualAddress + len(pe_s.data)]
+
+    addend_offset = reloc["r_offset"] - target.VirtualAddress
+
+    if reloc.is_RELA():
+        addend = reloc["r_addend"]
+    else:
+        addend = target.data[addend_offset : addend_offset + addend_size]
+        addend = int.from_bytes(addend, byteorder="little")
+
+    value = (image_base + addend).to_bytes(addend_size, byteorder="little")
+    target.data[addend_offset : addend_offset + addend_size] = value
+
+
+def convert_elf_reloc_table(
+    elf: ELFFile,
+    elf_reloc_table: ElfRelocationTable,
+    elf_image_base: int,
+    sections: typing.List[PeSection],
+    pe_reloc_blocks: typing.Dict[int, PeRelocationBlock],
+):
+    NONE_RELOC = {
+        "EM_386": ENUM_RELOC_TYPE_i386["R_386_NONE"],
+        "EM_AARCH64": ENUM_RELOC_TYPE_AARCH64["R_AARCH64_NONE"],
+        "EM_ARM": ENUM_RELOC_TYPE_ARM["R_ARM_NONE"],
+        "EM_LOONGARCH": 0,
+        "EM_RISCV": 0,
+        "EM_X86_64": ENUM_RELOC_TYPE_x64["R_X86_64_NONE"],
+    }[elf["e_machine"]]
+
+    RELATIVE_RELOC = {
+        "EM_386": ENUM_RELOC_TYPE_i386["R_386_RELATIVE"],
+        "EM_AARCH64": ENUM_RELOC_TYPE_AARCH64["R_AARCH64_RELATIVE"],
+        "EM_ARM": ENUM_RELOC_TYPE_ARM["R_ARM_RELATIVE"],
+        "EM_LOONGARCH": 3,
+        "EM_RISCV": 3,
+        "EM_X86_64": ENUM_RELOC_TYPE_x64["R_X86_64_RELATIVE"],
+    }[elf["e_machine"]]
+
+    for reloc in elf_reloc_table.iter_relocations():
+        if reloc["r_info_type"] == NONE_RELOC:
+            continue
+
+        if reloc["r_info_type"] == RELATIVE_RELOC:
+            apply_elf_relative_relocation(reloc,
+                                          elf_image_base,
+                                          sections,
+                                          elf.elfclass // 8)
+
+            # Now that the ELF relocation has been applied, we can create a PE relocation.
+            block_rva = reloc["r_offset"] & ~0xFFF
+            if block_rva not in pe_reloc_blocks:
+                pe_reloc_blocks[block_rva] = PeRelocationBlock(block_rva)
+
+            entry = PeRelocationEntry()
+            entry.Offset = reloc["r_offset"] & 0xFFF
+            # REL_BASED_HIGHLOW or REL_BASED_DIR64
+            entry.Type = 3 if elf.elfclass == 32 else 10
+            pe_reloc_blocks[block_rva].entries.append(entry)
+
+            continue
+
+        raise BadSectionError(f"Unsupported relocation {reloc}")
+
+
+def convert_elf_relocations(
+    elf: ELFFile,
+    opt: PeOptionalHeader,
+    sections: typing.List[PeSection],
+    minimum_sections: int,
+) -> typing.Optional[PeSection]:
+    dynamic = elf.get_section_by_name(".dynamic")
+    if dynamic is None:
+        raise BadSectionError("ELF .dynamic section is missing")
+
+    [flags_tag] = dynamic.iter_tags("DT_FLAGS_1")
+    if not flags_tag["d_val"] & ENUM_DT_FLAGS_1["DF_1_PIE"]:
+        raise ValueError("ELF file is not a PIE")
+
+    # This checks that the ELF image base is 0.
+    symtab = elf.get_section_by_name(".symtab")
+    if symtab:
+        exe_start = symtab.get_symbol_by_name("__executable_start")
+        if exe_start and exe_start[0]["st_value"] != 0:
+            raise ValueError("Unexpected ELF image base")
+
+    opt.SizeOfHeaders = align_to(PE_OFFSET
+                                 + len(PE_MAGIC)
+                                 + sizeof(PeCoffHeader)
+                                 + sizeof(opt)
+                                 + sizeof(PeSection) * max(len(sections) + 1, minimum_sections),
+                                 FILE_ALIGNMENT)
+
+    # We use the basic VMA layout from the ELF image in the PE image. This could cause the first
+    # section to overlap the PE image headers during runtime at VMA 0. We can simply apply a fixed
+    # offset relative to the PE image base when applying/converting ELF relocations. Afterwards we
+    # just have to apply the offset to the PE addresses so that the PE relocations work correctly on
+    # the ELF portions of the image.
+    segment_offset = 0
+    if sections[0].VirtualAddress < opt.SizeOfHeaders:
+        segment_offset = align_to(opt.SizeOfHeaders - sections[0].VirtualAddress,
+                                  SECTION_ALIGNMENT)
+
+    opt.AddressOfEntryPoint = elf["e_entry"] + segment_offset
+    opt.BaseOfCode += segment_offset
+    if isinstance(opt, PeOptionalHeader32):
+        opt.BaseOfData += segment_offset
+
+    pe_reloc_blocks: typing.Dict[int, PeRelocationBlock] = {}
+    for reloc_type, reloc_table in dynamic.get_relocation_tables().items():
+        if reloc_type not in ["REL", "RELA"]:
+            raise BadSectionError(f"Unsupported relocation type {reloc_type}")
+        convert_elf_reloc_table(elf,
+                                reloc_table,
+                                opt.ImageBase + segment_offset,
+                                sections,
+                                pe_reloc_blocks)
+
+    for pe_s in sections:
+        pe_s.VirtualAddress += segment_offset
+
+    if len(pe_reloc_blocks) == 0:
+        return None
+
+    data = bytearray()
+    for rva in sorted(pe_reloc_blocks):
+        block = pe_reloc_blocks[rva]
+        n_relocs = len(block.entries)
+
+        # Each block must start on a 32-bit boundary. Because each entry is 16 bits
+        # the len has to be even. We pad by adding a none relocation.
+        if n_relocs % 2 != 0:
+            n_relocs += 1
+            block.entries.append(PeRelocationEntry())
+
+        block.PageRVA += segment_offset
+        block.BlockSize = sizeof(PeRelocationBlock) + sizeof(PeRelocationEntry) * n_relocs
+        data += block
+        for entry in sorted(block.entries, key=lambda e: e.Offset):
+            data += entry
+
+    pe_reloc_s = PeSection()
+    pe_reloc_s.Name = b".reloc"
+    pe_reloc_s.data = data
+    pe_reloc_s.VirtualAddress = next_section_address(sections)
+    pe_reloc_s.VirtualSize = len(data)
+    pe_reloc_s.SizeOfRawData = align_to(len(data), FILE_ALIGNMENT)
+    # CNT_INITIALIZED_DATA|MEM_READ|MEM_DISCARDABLE
+    pe_reloc_s.Characteristics = 0x42000040
+
+    sections.append(pe_reloc_s)
+    opt.SizeOfInitializedData += pe_reloc_s.VirtualSize
+    return pe_reloc_s
+
+
+def write_pe(
+    file,
+    coff: PeCoffHeader,
+    opt: PeOptionalHeader,
+    sections: typing.List[PeSection],
+):
+    file.write(b"MZ")
+    file.seek(0x3C, io.SEEK_SET)
+    file.write(PE_OFFSET.to_bytes(2, byteorder="little"))
+    file.seek(PE_OFFSET, io.SEEK_SET)
+    file.write(PE_MAGIC)
+    file.write(coff)
+    file.write(opt)
+
+    offset = opt.SizeOfHeaders
+    for pe_s in sorted(sections, key=lambda s: s.VirtualAddress):
+        if pe_s.VirtualAddress < opt.SizeOfHeaders:
+            raise BadSectionError(f"Section {pe_s.Name} @0x{pe_s.VirtualAddress:x} overlaps"
+                                  " PE headers ending at 0x{opt.SizeOfHeaders:x}")
+
+        pe_s.PointerToRawData = offset
+        file.write(pe_s)
+        offset = align_to(offset + len(pe_s.data), FILE_ALIGNMENT)
+
+    assert file.tell() <= opt.SizeOfHeaders
+
+    for pe_s in sections:
+        file.seek(pe_s.PointerToRawData, io.SEEK_SET)
+        file.write(pe_s.data)
+
+    file.truncate(offset)
+
+
+def elf2efi(args: argparse.Namespace):
+    global FILE_ALIGNMENT
+    elf = ELFFile(args.ELF)
+    if not elf.little_endian:
+        raise ValueError("ELF file is not little-endian")
+    if elf["e_type"] not in ["ET_DYN", "ET_EXEC"]:
+        raise ValueError(f"Unsupported ELF type {elf['e_type']}")
+
+    # EDK2 on RISC-V expects 4KiB file alignment.
+    if elf["e_machine"] == "EM_RISCV":
+        FILE_ALIGNMENT = SECTION_ALIGNMENT
+    else:
+        FILE_ALIGNMENT = DEFAULT_FILE_ALIGNMENT
+
+    pe_arch = {
+        "EM_386": 0x014C,
+        "EM_AARCH64": 0xAA64,
+        "EM_ARM": 0x01C2,
+        "EM_LOONGARCH": 0x6232 if elf.elfclass == 32 else 0x6264,
+        "EM_RISCV": 0x5032 if elf.elfclass == 32 else 0x5064,
+        "EM_X86_64": 0x8664,
+    }.get(elf["e_machine"])
+    if pe_arch is None:
+        raise ValueError(f"Unsupported ELF architecture {elf['e_machine']}")
+
+    coff = PeCoffHeader()
+    opt = PeOptionalHeader32() if elf.elfclass == 32 else PeOptionalHeader32Plus()
+
+    # We relocate to a unique image base to reduce the chances for runtime relocation to occur.
+    base_name = pathlib.Path(args.PE.name).name.encode()
+    opt.ImageBase = int(hashlib.sha1(base_name).hexdigest()[0:8], 16)
+    if elf.elfclass == 32:
+        opt.ImageBase = (0x400000 + opt.ImageBase) & 0xFFFF0000
+    else:
+        opt.ImageBase = (0x100000000 + opt.ImageBase) & 0x1FFFF0000
+
+    sections = convert_sections(elf, opt)
+    copy_sections(elf, opt, args.copy_sections, sections)
+    pe_reloc_s = convert_elf_relocations(elf, opt, sections, args.minimum_sections)
+
+    coff.Machine = pe_arch
+    coff.NumberOfSections = len(sections)
+    coff.TimeDateStamp = int(os.environ.get("SOURCE_DATE_EPOCH") or time.time())
+    coff.SizeOfOptionalHeader = sizeof(opt)
+    # EXECUTABLE_IMAGE|LINE_NUMS_STRIPPED|LOCAL_SYMS_STRIPPED|DEBUG_STRIPPED
+    # and (32BIT_MACHINE or LARGE_ADDRESS_AWARE)
+    coff.Characteristics = 0x30E if elf.elfclass == 32 else 0x22E
+
+    opt.SectionAlignment = SECTION_ALIGNMENT
+    opt.FileAlignment = FILE_ALIGNMENT
+    opt.MajorImageVersion = args.version_major
+    opt.MinorImageVersion = args.version_minor
+    opt.MajorSubsystemVersion = args.efi_major
+    opt.MinorSubsystemVersion = args.efi_minor
+    opt.Subsystem = args.subsystem
+    opt.Magic = 0x10B if elf.elfclass == 32 else 0x20B
+    opt.SizeOfImage = next_section_address(sections)
+
+    # DYNAMIC_BASE|HIGH_ENTROPY_VA or DYNAMIC_BASE
+    opt.DllCharacteristics = 0x60 if elf.elfclass == 64 else 0x40
+
+    # These values are taken from a natively built PE binary (although, unused by EDK2/EFI).
+    opt.SizeOfStackReserve = 0x100000
+    opt.SizeOfStackCommit = 0x001000
+    opt.SizeOfHeapReserve = 0x100000
+    opt.SizeOfHeapCommit = 0x001000
+
+    opt.NumberOfRvaAndSizes = N_DATA_DIRECTORY_ENTRIES
+    if pe_reloc_s:
+        opt.BaseRelocationTable = PeDataDirectory(
+            pe_reloc_s.VirtualAddress, pe_reloc_s.VirtualSize
+        )
+
+    write_pe(args.PE, coff, opt, sections)
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Convert ELF binaries to PE/EFI")
+    parser.add_argument(
+        "--version-major",
+        type=int,
+        default=0,
+        help="Major image version of EFI image",
+    )
+    parser.add_argument(
+        "--version-minor",
+        type=int,
+        default=0,
+        help="Minor image version of EFI image",
+    )
+    parser.add_argument(
+        "--efi-major",
+        type=int,
+        default=0,
+        help="Minimum major EFI subsystem version",
+    )
+    parser.add_argument(
+        "--efi-minor",
+        type=int,
+        default=0,
+        help="Minimum minor EFI subsystem version",
+    )
+    parser.add_argument(
+        "--subsystem",
+        type=int,
+        default=10,
+        help="PE subsystem",
+    )
+    parser.add_argument(
+        "ELF",
+        type=argparse.FileType("rb"),
+        help="Input ELF file",
+    )
+    parser.add_argument(
+        "PE",
+        type=argparse.FileType("wb"),
+        help="Output PE/EFI file",
+    )
+    parser.add_argument(
+        "--minimum-sections",
+        type=int,
+        default=0,
+        help="Minimum number of sections to leave space for",
+    )
+    parser.add_argument(
+        "--copy-sections",
+        type=str,
+        default="",
+        help="Copy these sections if found",
+    )
+    return parser
+
+
+def main():
+    parser = create_parser()
+    elf2efi(parser.parse_args())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/vm_manage.py
+++ b/scripts/vm_manage.py
@@ -5,17 +5,30 @@
 
 import argparse
 import copy
-import guestfs
 import json
 import os
-import pefile
 import platform
-import requests
 import shutil
 import struct
 import subprocess
 import time
 import uuid
+
+import guestfs
+import pefile
+import requests
+
+# pylint: disable=consider-using-with
+# pylint: disable=duplicate-code
+# pylint: disable=line-too-long
+# pylint: disable=missing-class-docstring
+# pylint: disable=missing-function-docstring
+# pylint: disable=raise-missing-from
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-branches
+# pylint: disable=too-many-locals
+# pylint: disable=too-many-positional-arguments
+# pylint: disable=too-many-statements
 
 # Enable DEBUG mode
 DEBUG = False
@@ -60,6 +73,18 @@ VM_DEFAULTS = {
             "vars": "AAVMF_VARS.fd",
         },
     },
+    "riscv64": {
+        "arch": "riscv64",
+        "machine": "virt",
+        "cpu": {
+            "model": "rva23s64",
+        },
+        "fw": {
+            "dir": "/usr/share/qemu-efi-riscv64",
+            "code": "RISCV_VIRT_CODE.fd",
+            "vars": "RISCV_VIRT_VARS.fd",
+        },
+    },
 }
 
 # EFI system partition type GUID
@@ -78,6 +103,7 @@ ssh_pwauth: True
 EFI_SUFFIXES = {
     "x86_64": "X64.EFI",
     "aarch64": "AA64.EFI",
+    "riscv64": "RISCV64.EFI",
 }
 
 
@@ -96,7 +122,7 @@ class GPTPartition:
             raise ValueError("Partition entry must be at least 128 bytes")
 
         type_guid_bytes = entry_bytes[:16]
-        if type_guid_bytes == b'\x00' * 16:
+        if type_guid_bytes == b"\x00" * 16:
             return None
 
         unique_guid_bytes = entry_bytes[16:32]
@@ -106,7 +132,7 @@ class GPTPartition:
         name_bytes = entry_bytes[56:128]
 
         # Decode name (UTF-16LE, null-terminated)
-        name = name_bytes.decode('utf-16-le').split('\x00')[0]
+        name = name_bytes.decode("utf-16-le").split("\x00")[0]
 
         type_guid = uuid.UUID(bytes_le=type_guid_bytes)
         unique_guid = uuid.UUID(bytes_le=unique_guid_bytes)
@@ -188,6 +214,8 @@ def ubuntu_cloud_url(release, arch):
         arch = "amd64"
     elif arch == "aarch64":
         arch = "arm64"
+    elif arch == "riscv64":
+        arch = "riscv64"
     else:
         raise ValueError(f"Unsupported architecture for Ubuntu cloud image: {arch}")
 
@@ -218,6 +246,41 @@ def best_vm_accel(vm_arch):
     if platform.machine() == vm_arch:
         return "kvm"  # Use hardware acceleration if host and target arch match
     return "tcg"  # Use software emulation if host and target arch differ
+
+
+def disk_device_for_arch(arch):
+    """Return a virtio block device suitable for the target architecture."""
+    if arch == "riscv64":
+        return "virtio-blk-device"
+    return "virtio-blk-pci"
+
+
+def efi_build_target(arch):
+    """Return the Rust target triple used to build EFI payloads."""
+    if arch == "riscv64":
+        return "riscv64imac-unknown-none-elf"
+    return f"{arch}-unknown-uefi"
+
+
+def build_efi_binary(package, arch):
+    """Build an EFI binary for the given package and architecture."""
+    scripts_dir = os.path.dirname(os.path.abspath(__file__))
+    subprocess.run(
+        [
+            "python3",
+            os.path.join(scripts_dir, "build_efi.py"),
+            "--package",
+            package,
+            "--arch",
+            arch,
+        ],
+        check=True,
+    )
+
+    efi_path = os.path.join("target", efi_build_target(arch), "debug", f"{package}.efi")
+    if not os.path.exists(efi_path):
+        raise RuntimeError(f"Build failed: {efi_path} not found")
+    return efi_path
 
 
 def create_disk_image(args):
@@ -362,21 +425,7 @@ def build_and_inject_stubble(args, config):
     """Build lace-stubble and inject it into the VM disk image"""
 
     # Build lace-stubble
-    stubble_target = f"{config['arch']}-unknown-uefi"
-    subprocess.run(
-        [
-            "cargo",
-            "build",
-            "-p",
-            "lace-stubble",
-            "--no-default-features",
-            "--features",
-            "efi",
-            "--target",
-            stubble_target,
-        ],
-        check=True,
-    )
+    stubble_efi_path = build_efi_binary("lace-stubble", config["arch"])
 
     # Open disk image for read/write
     disk_image_path = os.path.join(args.dir, "disk.img")
@@ -423,9 +472,6 @@ def build_and_inject_stubble(args, config):
         )
 
     # Create stubble EFI binary
-    stubble_efi_path = os.path.join(
-        "target", stubble_target, "debug", "lace-stubble.efi"
-    )
     output_efi_path = os.path.join(args.dir, "stubble.efi")
     pewrap_cmd = [
         "cargo",
@@ -468,22 +514,7 @@ def build_and_inject_speedboot(args, config):
     """Replace BOOT{EFI_SUFFIXES[config['arch']]}.efi with lace-speedboot"""
 
     print("Building lace-speedboot...")
-    subprocess.run(
-        [
-            "cargo",
-            "build",
-            "-p",
-            "lace-speedboot",
-            "--no-default-features",
-            "--features",
-            "efi",
-            "--target",
-            f"{config['arch']}-unknown-uefi",
-        ],
-        check=True,
-    )
-
-    speedboot_path = f"target/{config['arch']}-unknown-uefi/debug/lace-speedboot.efi"
+    speedboot_path = build_efi_binary("lace-speedboot", config["arch"])
     if not os.path.exists(speedboot_path):
         raise RuntimeError(f"Build failed: {speedboot_path} not found")
 
@@ -542,7 +573,8 @@ def build_and_inject_bios(args, config, package):
         "bios",
         "--target",
         "lace-platform/src/bios/x86_64-bios.json",
-        "-Z", "json-target-spec",
+        "-Z",
+        "json-target-spec",
         "-Z",
         "build-std=core,alloc,compiler_builtins",
         "-Z",
@@ -691,7 +723,7 @@ def do_start(args):
             "--log",
             "level=0",
         ]
-        print(f"Starting swtpm...")
+        print("Starting swtpm...")
         swtpm_proc = subprocess.Popen(swtpm_cmd)
 
         # Wait for socket
@@ -747,7 +779,7 @@ def do_start(args):
                     f"if=none,id=disk,format={config['disk']['format']},file="
                     + os.path.join(args.dir, config["disk"]["file"]),
                     "-device",
-                    "virtio-blk-pci,drive=disk,bootindex=1",
+                    f"{disk_device_for_arch(config['arch'])},drive=disk,bootindex=1",
                 ]
             )
 
@@ -808,7 +840,7 @@ def do_start(args):
                     "-drive",
                     f"file=fat:rw:{edid_drive},format=raw,if=none,id=edid_drive",
                     "-device",
-                    "virtio-blk-pci,drive=edid_drive,bootindex=0",
+                    f"{disk_device_for_arch(config['arch'])},drive=edid_drive,bootindex=0",
                 ]
             )
 
@@ -840,6 +872,7 @@ def do_start(args):
             swtpm_proc.terminate()
             swtpm_proc.wait()
 
+
 def main():
     """Main function to parse arguments and execute commands"""
 
@@ -868,7 +901,10 @@ def main():
 
     start_cmd = cmds.add_parser("start", help="Start the VM")
     start_cmd.add_argument(
-        "--app", type=str, default="stubble", help="App to run (stubble, speedboot, speedboot-bios)"
+        "--app",
+        type=str,
+        default="stubble",
+        help="App to run (stubble, speedboot, speedboot-bios)",
     )
 
     args = parser.parse_args()

--- a/tools/pewrap/src/main.rs
+++ b/tools/pewrap/src/main.rs
@@ -387,7 +387,8 @@ impl<'s> PeRebuilder<'s> {
                 unaligned_size_of_headers = min_section_virtual_address;
             }
         }
-        // Loaded image size starts with the size of headers rounded to section alignment
+        // Loaded image size is the maximum aligned end RVA across headers and
+        // all section mappings.
         self.nt_hdrs.optional_header.size_of_image = align_up!(
             unaligned_size_of_headers,
             self.nt_hdrs.optional_header.section_alignment
@@ -436,10 +437,17 @@ impl<'s> PeRebuilder<'s> {
             if (shdr.characteristics & SCN_CNT_UNINITIALIZED_DATA) > 0 {
                 self.nt_hdrs.optional_header.size_of_uninitialized_data += shdr.size_of_raw_data;
             }
-            self.nt_hdrs.optional_header.size_of_image += align_up!(
-                shdr.virtual_size,
+            let mapped_size = if shdr.virtual_size == 0 {
+                shdr.size_of_raw_data
+            } else {
+                shdr.virtual_size
+            };
+            let section_end = align_up!(
+                shdr.virtual_address.saturating_add(mapped_size),
                 self.nt_hdrs.optional_header.section_alignment
             );
+            self.nt_hdrs.optional_header.size_of_image =
+                self.nt_hdrs.optional_header.size_of_image.max(section_end);
         }
 
         Ok(())


### PR DESCRIPTION
This PR adds riscv64 EFI builds for `lace-stubble` and `lace-speedboot`, with QEMU used as the current test environment.

### What was required for riscv64 support

1. Added riscv64 handling in `scripts/vm_manage.py`:
   - riscv64 defaults (QEMU machine/firmware paths)
   - riscv64 EFI boot filename handling
   - riscv64 Ubuntu cloud image mapping
   - riscv64-specific disk device selection for QEMU

2. Split EFI building into `scripts/build_efi.py` and wired
   `vm_manage.py` to call it, so riscv64 EFI artifacts are built through a
   dedicated, reusable path.

3. Implemented the riscv64 EFI build strategy:
   - use `-Z build-std=core,alloc,compiler_builtins`
   - use `-Z build-std-features=mem`
   - produce riscv64 ELF and convert it to EFI via `scripts/elf2efi.py`

4. Fixed `tools/pewrap` PE optional-header `SizeOfImage` computation so
   wrapped riscv64 EFI images load correctly in EDK2 (this was required to
   eliminate load failures).

### Current status

`lace-stubble` and `lace-speedboot` are known to work in riscv64 QEMU
testing.  
Testing on real riscv64 hardware is still outstanding.
